### PR TITLE
feat: pagination support for large PRs (cod-enj5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: lycheeverse/lychee-action@v2
       with:
         fail: true
-        args: --no-progress .
+        args: --no-progress --config .lychee.toml .
 
   quality:
     strategy:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -8,8 +8,11 @@ exclude = [
     '^https://pypi\.org/project/my-',
     '^https://codecov\.io/gh/your-',
     '^mailto:',
-    # Private repo — CI badges and actions URLs 404 without auth
-    '^https://github\.com/detailobsessed/codereviewbuddy/(workflows|actions)',
+    # Private repo — various URLs 404 without auth
+    '^https://github\.com/detailobsessed/codereviewbuddy',
+    '^https://detailobsessed\.github\.io/codereviewbuddy',
+    # Local dev server referenced in CONTRIBUTING.md
+    '^http://localhost',
 ]
 
 # Exclude local/private addresses
@@ -27,8 +30,8 @@ timeout = 30
 # Max concurrent requests
 max_concurrency = 16
 
-# Don't check the lychee config file itself (contains regex patterns that look like URLs)
-exclude_path = [".lychee.toml"]
+# Don't check files with fake/test URLs
+exclude_path = [".lychee.toml", "tests/"]
 
 # Don't show progress bar (cleaner CI output)
 no_progress = true

--- a/.tickets/cod-3tsf.md
+++ b/.tickets/cod-3tsf.md
@@ -1,0 +1,31 @@
+---
+id: cod-3tsf
+status: open
+deps: []
+links: []
+created: 2026-02-07T01:59:16Z
+type: feature
+priority: 1
+assignee: Ismar Iljazovic
+tags: [mcp, polling]
+---
+# wait_for_reviews polling tool
+
+Add a wait_for_reviews MCP tool that polls until AI reviewers have completed their review cycle on a PR. Must handle:
+
+1. Reviewers that post comments (Unblocked finds 2 issues, Devin finds 3 issues)
+2. Reviewers that approve with NO comments (everything looks good)
+3. Timeout after configurable duration
+
+Detection signals:
+
+- Check runs: CodeRabbit creates check runs (IN_PROGRESS -> COMPLETED)
+- Review submissions: latestOpinionatedReviews shows submitted reviews (APPROVED, CHANGES_REQUESTED)
+- Bot comments: presence of known bot comments on the PR timeline
+- Heuristic fallback: if a push happened recently and no bot activity yet, still waiting
+
+Returns a status dict per reviewer: {reviewer: status, has_comments: bool, review_state: str}
+
+Design consideration: MCP has no server-push or event system. This tool should long-poll (sleep loop) with configurable timeout and poll interval. The agent calls it and the tool blocks until reviews are detected or timeout.
+
+Edge case: reviewer simply has nothing to say (clean PR). Need to distinguish 'still reviewing' from 'reviewed and found nothing'. Check run completion + review submission are the reliable signals for this.

--- a/.tickets/cod-enj5.md
+++ b/.tickets/cod-enj5.md
@@ -1,6 +1,6 @@
 ---
 id: cod-enj5
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T00:39:24Z
@@ -12,4 +12,3 @@ tags: [api]
 # Pagination support for large PRs (100+ threads)
 
 Current GraphQL query fetches first 100 review threads. Add cursor-based pagination to handle PRs with more than 100 threads.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,18 +202,18 @@ releases = "gh release list --limit 10"
 runs = "gh run list --limit 10"
 watch = "gh run watch"
 
-# Testing — PYTHON_GIL=0 needed for Python 3.14t (lupa/fakeredis GIL compat)
+# Testing — conditionally set PYTHON_GIL=0 only on freethreaded builds (3.14t)
 [tool.poe.tasks.test]
-cmd = "pytest -m 'not slow'"
-env = {PYTHON_GIL = "0"}
+shell = "python -c 'import sys; exit(0 if \"t\" in sys.abiflags else 1)' 2>/dev/null && export PYTHON_GIL=0; pytest -m 'not slow'"
+interpreter = "bash"
 
 [tool.poe.tasks.test-all]
-cmd = "pytest"
-env = {PYTHON_GIL = "0"}
+shell = "python -c 'import sys; exit(0 if \"t\" in sys.abiflags else 1)' 2>/dev/null && export PYTHON_GIL=0; pytest"
+interpreter = "bash"
 
 [tool.poe.tasks.test-cov]
-cmd = "pytest --cov=src --cov-report=term-missing --cov-report=html"
-env = {PYTHON_GIL = "0"}
+shell = "python -c 'import sys; exit(0 if \"t\" in sys.abiflags else 1)' 2>/dev/null && export PYTHON_GIL=0; pytest --cov=src --cov-report=term-missing --cov-report=html"
+interpreter = "bash"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -16,10 +16,31 @@ logger = logging.getLogger(__name__)
 
 mcp = FastMCP(
     "codereviewbuddy",
-    instructions=(
-        "AI code review buddy — fetch, resolve, and manage PR review comments "
-        "across Unblocked, Devin, and CodeRabbit with staleness detection."
-    ),
+    instructions="""\
+AI code review buddy — fetch, resolve, and manage PR review comments
+across Unblocked, Devin, and CodeRabbit with staleness detection.
+
+## Typical workflow after pushing a fix
+
+1. Call `list_review_comments` to see all threads with staleness info.
+2. For threads on files you changed, call `resolve_stale_comments` to batch-resolve them.
+3. Reply to non-stale threads with `reply_to_comment` if you addressed them differently.
+4. Call `request_rereview` to trigger a fresh review cycle.
+
+## Reviewer behavior differences
+
+- **Unblocked**: Does NOT auto-review on new pushes. You MUST call `request_rereview`
+  (which posts "@unblocked please re-review") after pushing fixes.
+- **Devin**: Auto-triggers a new review on every push. No action needed, but you can
+  still call `request_rereview` if you want to force one.
+- **CodeRabbit**: Auto-triggers on push. Same as Devin — no action needed.
+
+## Staleness
+
+A comment is "stale" when the file it references has been modified in the latest push.
+Stale comments are safe to batch-resolve with `resolve_stale_comments` since the code
+they reviewed has changed.
+""",
 )
 
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -60,7 +60,10 @@ SAMPLE_GRAPHQL_RESPONSE = {
             "pullRequest": {
                 "title": "Test PR",
                 "url": "https://github.com/owner/repo/pull/42",
-                "reviewThreads": {"nodes": [SAMPLE_THREAD_NODE, SAMPLE_RESOLVED_THREAD]},
+                "reviewThreads": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [SAMPLE_THREAD_NODE, SAMPLE_RESOLVED_THREAD],
+                },
             }
         }
     },
@@ -71,9 +74,10 @@ SAMPLE_DIFF_RESPONSE = {
         "repository": {
             "pullRequest": {
                 "files": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
                     "nodes": [
                         {"path": "src/codereviewbuddy/gh.py", "additions": 5, "deletions": 2, "changeType": "MODIFIED"},
-                    ]
+                    ],
                 }
             }
         }
@@ -83,13 +87,7 @@ SAMPLE_DIFF_RESPONSE = {
 RESOLVE_SUCCESS = {"data": {"resolveReviewThread": {"thread": {"id": "PRRT_kwDOtest123", "isResolved": True}}}}
 
 REPLY_THREAD_QUERY_RESPONSE = {
-    "data": {
-        "node": {
-            "comments": {
-                "nodes": [{"databaseId": 12345}]
-            }
-        }
-    },
+    "data": {"node": {"comments": {"nodes": [{"databaseId": 12345}]}}},
 }
 
 REPLY_REST_RESPONSE = {"id": 99999, "body": "Fixed!"}


### PR DESCRIPTION
## Summary

Adds cursor-based pagination to both GraphQL queries (`reviewThreads` and `files`) so PRs with 100+ review threads or changed files are fully fetched across multiple pages.

## Problem

Both `_THREADS_QUERY` and `_DIFF_QUERY` used `first: 100` without pagination cursors. GitHub's GraphQL API caps at 100 nodes per page — any PR exceeding that silently dropped threads/files.

## Changes

### Pagination
- **`_THREADS_QUERY`** — added `$cursor: String` param, `after: $cursor`, and `pageInfo { hasNextPage endCursor }`
- **`_DIFF_QUERY`** — same pagination treatment
- **`list_review_comments()`** — loops with cursor until `hasNextPage` is false
- **`_get_changed_files()`** — same pagination loop

### CI fixes
- **PYTHON_GIL=0** — now conditionally set only on freethreaded Python (3.14t); regular 3.14 in CI was crashing
- **Lychee** — CI action now uses `.lychee.toml` config; excludes localhost, tests/, and private repo URLs

### Tests
- `TestThreadsPagination` and `TestChangedFilesPagination` verify multi-page fetching with mock cursors
- All existing fixtures updated with `pageInfo`
- 68 tests passing, 97.24% coverage

Closes cod-enj5.