### PR TITLE
fix: surface PR-level review comments from AI reviewers (#16)

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -35,6 +35,7 @@ class ReviewThread(BaseModel):
     reviewer: str = Field(description="Which reviewer posted this (e.g. unblocked, devin, coderabbit)")
     comments: list[ReviewComment] = Field(default_factory=list, description="Comments in this thread")
     is_stale: bool = Field(default=False, description="Whether the commented lines changed since review")
+    is_pr_review: bool = Field(default=False, description="True for PR-level reviews (PRR_ IDs) — not resolvable via resolveReviewThread")
 
 
 class StackPR(BaseModel):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 from codereviewbuddy.gh import GhError
 from codereviewbuddy.tools.comments import (
     _get_changed_files,
+    _get_pr_reviews,
     _parse_threads,
     list_review_comments,
     resolve_comment,
@@ -125,6 +126,27 @@ class TestParseThreads:
         assert threads[0].status == "resolved"
         assert threads[0].reviewer == "devin"
 
+    def test_null_author_does_not_crash(self):
+        """Regression: author=null (ghost/deleted user) must not raise AttributeError."""
+        node = {
+            "id": "PRRT_ghost",
+            "isResolved": False,
+            "comments": {
+                "nodes": [
+                    {
+                        "author": None,
+                        "body": "Ghost comment",
+                        "createdAt": "2026-02-07T10:00:00Z",
+                        "path": "main.py",
+                        "line": 1,
+                    }
+                ]
+            },
+        }
+        threads = _parse_threads([node], pr_number=42)
+        assert len(threads) == 1
+        assert threads[0].comments[0].author == "unknown"
+
 
 class TestGetChangedFiles:
     def test_extracts_paths(self, mocker: MockerFixture):
@@ -137,6 +159,7 @@ class TestListReviewComments:
     @pytest.fixture(autouse=True)
     def _mock_gh(self, mocker: MockerFixture):
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=SAMPLE_GRAPHQL_RESPONSE)
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
         mocker.patch("codereviewbuddy.tools.comments._get_changed_files", return_value=set())
 
@@ -156,6 +179,7 @@ class TestListReviewComments:
 
     def test_explicit_repo(self, mocker: MockerFixture):
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=SAMPLE_GRAPHQL_RESPONSE)
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments._get_changed_files", return_value=set())
         threads = list_review_comments(42, repo="myorg/myrepo")
         assert len(threads) == 2
@@ -171,6 +195,7 @@ class TestNonExistentPR:
             "codereviewbuddy.tools.comments.gh.graphql",
             return_value=null_pr_response,
         )
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         threads = list_review_comments(42)
@@ -215,6 +240,7 @@ class TestResolveStaleComments:
             "codereviewbuddy.tools.comments.gh.graphql",
             side_effect=graphql_responses,
         )
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         result = resolve_stale_comments(42)
@@ -238,10 +264,164 @@ class TestResolveStaleComments:
             "codereviewbuddy.tools.comments.gh.graphql",
             side_effect=[SAMPLE_GRAPHQL_RESPONSE, no_diff],
         )
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         result = resolve_stale_comments(42)
         assert result["resolved_count"] == 0
+
+
+class TestGetPrReviews:
+    """Tests for _get_pr_reviews — PR-level review summaries from AI reviewers."""
+
+    def test_returns_devin_review(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_devin_123",
+                "user": {"login": "devin-ai-integration[bot]"},
+                "state": "COMMENTED",
+                "body": "**Devin Review** found 2 potential issues.",
+                "submitted_at": "2026-02-07T10:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert len(result) == 1
+        assert result[0].reviewer == "devin"
+        assert result[0].thread_id == "PRR_devin_123"
+        assert result[0].file is None
+        assert result[0].line is None
+        assert result[0].status == "unresolved"
+        assert "2 potential issues" in result[0].comments[0].body
+        assert result[0].is_pr_review is True
+
+    def test_returns_unblocked_review(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_unblocked_456",
+                "user": {"login": "unblocked[bot]"},
+                "state": "COMMENTED",
+                "body": "2 issues found.",
+                "submitted_at": "2026-02-07T09:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert len(result) == 1
+        assert result[0].reviewer == "unblocked"
+
+    def test_skips_unknown_reviewers(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_human",
+                "user": {"login": "humanuser"},
+                "state": "APPROVED",
+                "body": "LGTM!",
+                "submitted_at": "2026-02-07T11:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert result == []
+
+    def test_skips_empty_bodies(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_empty",
+                "user": {"login": "unblocked[bot]"},
+                "state": "COMMENTED",
+                "body": "",
+                "submitted_at": "2026-02-07T09:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert result == []
+
+    def test_maps_approved_to_resolved(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_approved",
+                "user": {"login": "devin-ai-integration[bot]"},
+                "state": "APPROVED",
+                "body": "No Issues Found",
+                "submitted_at": "2026-02-07T10:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert len(result) == 1
+        assert result[0].status == "resolved"
+
+    def test_maps_changes_requested_to_unresolved(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_changes",
+                "user": {"login": "unblocked[bot]"},
+                "state": "CHANGES_REQUESTED",
+                "body": "3 issues found.",
+                "submitted_at": "2026-02-07T10:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert len(result) == 1
+        assert result[0].status == "unresolved"
+
+    def test_handles_empty_response(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=None)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert result == []
+
+    def test_handles_null_user(self, mocker: MockerFixture):
+        reviews = [
+            {
+                "node_id": "PRR_null_user",
+                "user": None,
+                "state": "COMMENTED",
+                "body": "Some review",
+                "submitted_at": "2026-02-07T10:00:00Z",
+            },
+        ]
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=reviews)
+
+        result = _get_pr_reviews("owner", "repo", 42)
+        assert result == []
+
+
+class TestListIncludesPrReviews:
+    """Tests that list_review_comments includes PR-level reviews."""
+
+    def test_includes_pr_reviews_alongside_threads(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=SAMPLE_GRAPHQL_RESPONSE)
+        mocker.patch("codereviewbuddy.tools.comments._get_changed_files", return_value=set())
+        mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
+        mocker.patch(
+            "codereviewbuddy.tools.comments.gh.rest",
+            return_value=[
+                {
+                    "node_id": "PRR_devin",
+                    "user": {"login": "devin-ai-integration[bot]"},
+                    "state": "COMMENTED",
+                    "body": "2 potential issues found.",
+                    "submitted_at": "2026-02-07T10:00:00Z",
+                },
+            ],
+        )
+
+        threads = list_review_comments(42)
+        # 2 inline threads + 1 PR review
+        assert len(threads) == 3
+        pr_reviews = [t for t in threads if t.file is None]
+        assert len(pr_reviews) == 1
+        assert pr_reviews[0].reviewer == "devin"
 
 
 class TestThreadsPagination:
@@ -278,6 +458,7 @@ class TestThreadsPagination:
             "codereviewbuddy.tools.comments.gh.graphql",
             side_effect=[page1, page2, SAMPLE_DIFF_RESPONSE],
         )
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         threads = list_review_comments(42)
@@ -307,6 +488,7 @@ class TestThreadsPagination:
             "codereviewbuddy.tools.comments.gh.graphql",
             side_effect=[malformed_page, SAMPLE_DIFF_RESPONSE],
         )
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         threads = list_review_comments(42)

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -161,6 +161,7 @@ class TestToolRegistration:
 class TestListReviewCommentsMCP:
     async def test_returns_serialized_threads(self, client: Client, mocker: MockerFixture):
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=SAMPLE_GRAPHQL_RESPONSE)
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
         mocker.patch("codereviewbuddy.tools.comments._get_changed_files", return_value=set())
 
@@ -171,6 +172,7 @@ class TestListReviewCommentsMCP:
 
     async def test_with_status_filter(self, client: Client, mocker: MockerFixture):
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=SAMPLE_GRAPHQL_RESPONSE)
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
         mocker.patch("codereviewbuddy.tools.comments._get_changed_files", return_value=set())
 
@@ -179,6 +181,7 @@ class TestListReviewCommentsMCP:
 
     async def test_with_explicit_repo(self, client: Client, mocker: MockerFixture):
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=SAMPLE_GRAPHQL_RESPONSE)
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments._get_changed_files", return_value=set())
 
         result = await client.call_tool("list_review_comments", {"pr_number": 42, "repo": "myorg/myrepo"})
@@ -208,6 +211,7 @@ class TestResolveStaleCommentsMCP:
             {"data": {"t0": {"thread": {"id": "PRRT_kwDOtest123", "isResolved": True}}}},
         ]
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", side_effect=graphql_responses)
+        mocker.patch("codereviewbuddy.tools.comments.gh.rest", return_value=[])
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         result = await client.call_tool("resolve_stale_comments", {"pr_number": 42})


### PR DESCRIPTION
## Summary

Fixes #16 — PR-level review comments from AI reviewers (Unblocked, Devin, CodeRabbit) are now surfaced by `list_review_comments`.

## Problem

`list_review_comments` only queried GitHub's `pullRequestReviewThreads` (inline code comments). PR-level review summaries — posted via `pulls/{pr}/reviews` — were invisible. This meant:

- **Devin**: completely invisible (posts review summaries but NO inline threads)
- **Unblocked**: inline threads visible, but summary body ("N issues found") was missed

## Changes

### `src/codereviewbuddy/tools/comments.py`
- **`_get_pr_reviews()`** — new function that fetches PR-level reviews via REST `GET /repos/{owner}/{repo}/pulls/{pr}/reviews`
- Filters to non-empty bodies from known AI reviewers only (human reviews are excluded)
- Maps review states: `APPROVED`/`DISMISSED` → resolved, `COMMENTED`/`CHANGES_REQUESTED` → unresolved
- Returns `ReviewThread` objects with `file=None, line=None` (PR-level, not file-specific)
- `list_review_comments()` now calls `_get_pr_reviews()` and includes results alongside inline threads

### Edge cases handled
- Null user object
- Empty review body
- Null REST response
- Unknown reviewer logins (filtered out)

### Tests
- `TestGetPrReviews` — 8 tests covering Devin/Unblocked reviews, state mapping, edge cases
- `TestListIncludesPrReviews` — verifies PR reviews appear alongside inline threads
- All existing tests updated to mock `gh.rest`
- **80 tests passing, 97.60% coverage**