### PR TITLE
feat: publish codereviewbuddy to PyPI (#18)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,41 +14,39 @@ permissions:
 jobs:
   release:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    concurrency: release
-    environment: pypi
+    uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
+    with:
+      pypi-publish: "false"
+    secrets: inherit
 
+  # PyPI publish must be in calling workflow for OIDC trusted publishing to work.
+  # Reusable workflow OIDC tokens contain the reusable workflow's repo in claims,
+  # not the calling repo — so PyPI trusted publishing rejects them.
+  pypi-publish:
+    needs: release
+    if: needs.release.outputs.released == 'true' && vars.PYPI_PUBLISH == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/codereviewbuddy
+    permissions:
+      contents: read
+      id-token: write
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        fetch-tags: true
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
 
-    - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7.1.5
-      with:
-        python-version: "3.14"
-        enable-cache: true
+      - name: Checkout latest release tag
+        run: git checkout "$(git describe --tags --abbrev=0)"
 
-    - name: Install dependencies
-      run: uv sync --group maintain
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
 
-    - name: Semantic Release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: uv run semantic-release version --changelog --push --tag --vcs-release
+      - name: Build package
+        run: uv build
 
-    - name: Check if release artifacts exist
-      id: dist
-      shell: bash
-      run: |
-        if compgen -G "dist/*" > /dev/null; then
-          echo "has_dist=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_dist=false" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Publish to PyPI
-      if: steps.dist.outputs.has_dist == 'true'
-      run: uv publish
+      - name: Publish to PyPI
+        run: uv publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.detailobsessed/codereviewbuddy -->
 # codereviewbuddy
 
 [![ci](https://github.com/detailobsessed/codereviewbuddy/workflows/ci/badge.svg)](https://github.com/detailobsessed/codereviewbuddy/actions?query=workflow%3Aci)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "ISC"
 license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.14"
-keywords = []
+keywords = ["mcp", "model-context-protocol", "code-review", "ai", "github", "pr", "unblocked", "devin", "coderabbit"]
 version = "0.1.1"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -27,6 +27,9 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.14.5",
 ]
+
+[project.scripts]
+codereviewbuddy = "codereviewbuddy.server:main"
 
 [project.urls]
 Homepage = "https://detailobsessed.github.io/codereviewbuddy"
@@ -217,6 +220,7 @@ interpreter = "bash"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
+version_variables = ["server.json:version"]
 branch = "main"
 build_command = """
 uv lock --upgrade-package "$PACKAGE_NAME"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.detailobsessed/codereviewbuddy",
+  "description": "MCP server that helps AI coding agents interact with AI code reviewers on GitHub PRs",
+  "repository": {
+    "url": "https://github.com/detailobsessed/codereviewbuddy",
+    "source": "github"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "codereviewbuddy",
+      "version": "0.1.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": []
+    }
+  ]
+}

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -143,6 +143,12 @@ def request_rereview(
     return rereview.request_rereview(pr_number, reviewer=reviewer, repo=repo)
 
 
+def main() -> None:
+    """Run the codereviewbuddy MCP server."""
+    check_prerequisites()
+    mcp.run()
+
+
 def check_prerequisites() -> None:
     """Verify that gh CLI is installed and authenticated."""
     try:


### PR DESCRIPTION
## Summary

Closes #18 — sets up everything needed to publish codereviewbuddy to PyPI via OIDC trusted publishing.

## Changes

### `release.yml`
- Migrated from inline release job to **`ci-components/semantic-release-uv.yml`** reusable workflow
- Added separate **`pypi-publish`** job — required because OIDC tokens from reusable workflows contain the reusable workflow's repo in claims, not the calling repo
- Gated on `vars.PYPI_PUBLISH == 'true'` repo variable

### `pyproject.toml`
- Added **`[project.scripts]`** entry point: `codereviewbuddy = "codereviewbuddy.server:main"`
- Added **keywords** for PyPI discoverability (mcp, code-review, github, etc.)
- Added **`version_variables`** to `[tool.semantic_release]` for `server.json` sync

### `server.py`
- Added **`main()`** function as CLI entry point (calls `check_prerequisites()` then `mcp.run()`)

### MCP Registry prep (#21)
- Created **`server.json`** with MCP server metadata schema
- Added **`<!-- mcp-name: ... -->`** ownership marker to README.md

## Manual steps after merge

1. **Configure PyPI trusted publishing** at https://pypi.org/manage/project/codereviewbuddy/settings/publishing/
   - Publisher: GitHub Actions
   - Repository: `detailobsessed/codereviewbuddy`
   - Workflow: `release.yml`
   - Environment: `pypi`
2. **Set repo variable** `PYPI_PUBLISH=true` in GitHub repo settings
3. **Ensure org membership is public** at https://github.com/orgs/detailobsessed/people

## Tests

81 passed, 97.41% coverage — no functional changes to server logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
