### PR TITLE
build: update copier template to 0.17.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.16.2
+_commit: 0.17.0
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic
@@ -9,6 +9,7 @@ include_template_dev_scripts: true
 project_description: codereview buddy helps your AI agent interact with AI code review--smoothly!
 project_name: codereviewbuddy
 project_type: app
+project_visibility: public
 publish_to_pypi: true
 repository_namespace: detailobsessed
 repository_provider: github.com
@@ -16,4 +17,3 @@ use_blacksmith_runners: true
 use_ci: true
 use_polar: false
 use_semantic_release: true
-

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,6 +1,9 @@
 # Lychee link checker configuration
 # https://github.com/lycheeverse/lychee
 
+# Don't check the config file itself or test fixtures
+exclude_path = [".lychee.toml", "tests/"]
+
 # Exclude placeholder and example URLs
 exclude = [
     '^https://example\.com',
@@ -29,9 +32,6 @@ timeout = 30
 
 # Max concurrent requests
 max_concurrency = 16
-
-# Don't check files with fake/test URLs
-exclude_path = [".lychee.toml", "tests/"]
 
 # Don't show progress bar (cleaner CI output)
 no_progress = true


### PR DESCRIPTION
## Summary

Updates the copier template from `0.16.2` to `0.17.0`.

## Changes

- **`.copier-answers.yml`** — version bump + new `project_visibility: public` field
- **`.lychee.toml`** — resolved merge conflict, consolidated duplicate `exclude_path` entries into one
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
