### PR TITLE
fix(ci): pass python-version 3.14 to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
     with:
+      python-version: "3.14"
       pypi-publish: "false"
     secrets: inherit
 
@@ -43,7 +44,9 @@ jobs:
         run: git checkout "$(git describe --tags --abbrev=0)"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7.1.5
+        with:
+          python-version: "3.14"
 
       - name: Build package
         run: uv build


### PR DESCRIPTION
## Summary

Fixes the release workflow failure caused by Python version mismatch.

The `ci-components/semantic-release-uv.yml` reusable workflow defaults to Python 3.13, but this project requires `>=3.14`. Added `python-version: "3.14"` to both the release job and the pypi-publish job.

## Root cause

```
error: The requested interpreter resolved to Python 3.13.12, which is incompatible
with the project's Python requirement: `>=3.14` (from `project.requires-python`)
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
