### PR TITLE
feat: add MCP Registry publish workflow (#21)

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,17 @@
+name: MCP Registry Publish
+
+"on":
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish-bun.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 .env.*
 !.env.example
 
+# mcp-publisher tokens
+.mcpregistry_*
+
 # tools
 .coverage*
 /.pdm-build/


### PR DESCRIPTION
## Summary

Adds automated MCP Registry publishing on each GitHub release, and gitignores `mcp-publisher` token files.

Closes #21

## Changes

- **`.github/workflows/mcp-registry-publish.yml`** — triggers on `release: published` or `workflow_dispatch`, uses `ci-components` reusable workflow with OIDC auth
- **`.gitignore`** — add `.mcpregistry_*` pattern to ignore token files from `mcp-publisher login`

## Context

- First manual publish already done: `io.github.detailobsessed/codereviewbuddy` v0.1.1 is live on the [MCP Registry](https://registry.modelcontextprotocol.io/)
- `server.json` already exists with `runtimeHint: "uvx"` and version synced via `version_variables`
- README already has the `<!-- mcp-name: ... -->` ownership marker
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
