### PR TITLE
feat: add list_stack_review_comments batch tool (#3)

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -65,6 +65,29 @@ def list_review_comments(
 
 
 @mcp.tool
+def list_stack_review_comments(
+    pr_numbers: list[int],
+    repo: str | None = None,
+    status: str | None = None,
+) -> dict[int, list[dict]]:
+    """List review threads for multiple PRs in a stack, grouped by PR number.
+
+    Collapses N tool calls into 1 for the common stacked-PR review workflow.
+    Gives the agent a full picture of the review state before deciding what to fix.
+
+    Args:
+        pr_numbers: List of PR numbers to fetch comments for.
+        repo: Repository in "owner/repo" format. Auto-detected from git remote if not provided.
+        status: Filter by "resolved" or "unresolved". Returns all if not set.
+
+    Returns:
+        Dict mapping each PR number to its list of review threads.
+    """
+    results = comments.list_stack_review_comments(pr_numbers, repo=repo, status=status)
+    return {pr: [t.model_dump(mode="json") for t in threads] for pr, threads in results.items()}
+
+
+@mcp.tool
 def resolve_comment(
     pr_number: int,
     thread_id: str,

--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -256,6 +256,31 @@ def list_review_comments(
     return threads
 
 
+def list_stack_review_comments(
+    pr_numbers: list[int],
+    repo: str | None = None,
+    status: str | None = None,
+    cwd: str | None = None,
+) -> dict[int, list[ReviewThread]]:
+    """List review threads for multiple PRs in a stack, grouped by PR number.
+
+    Collapses N tool calls into 1 for the common stacked-PR review workflow.
+
+    Args:
+        pr_numbers: List of PR numbers to fetch comments for.
+        repo: Repository in "owner/repo" format. Auto-detected if not provided.
+        status: Filter by "resolved" or "unresolved". Returns all if not set.
+        cwd: Working directory for git operations.
+
+    Returns:
+        Dict mapping each PR number to its list of ReviewThread objects.
+    """
+    results: dict[int, list[ReviewThread]] = {}
+    for pr_number in pr_numbers:
+        results[pr_number] = list_review_comments(pr_number, repo=repo, status=status, cwd=cwd)
+    return results
+
+
 def resolve_comment(
     pr_number: int,
     thread_id: str,


### PR DESCRIPTION
## Summary

Adds `list_stack_review_comments` tool that fetches review threads for multiple PRs in a single call, grouped by PR number. Designed for the stacked-PR review workflow where an agent needs to inspect an entire Graphite stack.

Closes #3

## Changes

- **`src/codereviewbuddy/tools/comments.py`** — `list_stack_review_comments()` iterates over PR numbers and delegates to `list_review_comments`
- **`src/codereviewbuddy/server.py`** — register as `@mcp.tool` with serialization
- **`tests/test_comments.py`** — unit tests: grouped results, status filter passthrough, empty input
- **`tests/test_mcp_integration.py`** — integration test through MCP protocol + updated tool count/registry assertions

## Example

```
list_stack_review_comments(pr_numbers=[119,120,121], repo="owner/repo")
→ {
    119: [{thread_id, file, line, reviewer, status, is_stale, comments}],
    120: [],
    121: [{...}],
  }
```

## Context

Previously, reviewing a 6-PR Graphite stack required 6 separate `list_review_comments` calls. This collapses them into 1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
