### PR TITLE
feat: use FastMCP Context for progress reporting and logging (#5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ maintain = [
     "python-semantic-release>=10",
 ]
 ci = [
-    "ruff>=0.14",
+    "ruff>=0.15",
     "pytest>=8",
     "pytest-cov>=6",
     "pytest-randomly>=3.15",

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -62,3 +62,4 @@ class ResolveStaleResult(TypedDict):
 
     resolved_count: int
     resolved_thread_ids: list[str]
+    skipped_count: int

--- a/src/codereviewbuddy/tools/rereview.py
+++ b/src/codereviewbuddy/tools/rereview.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-import logging
+from typing import TYPE_CHECKING
 
 from codereviewbuddy import gh
 from codereviewbuddy.reviewers import REVIEWERS, get_reviewer
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from fastmcp.server.context import Context
 
 
-def request_rereview(
+async def request_rereview(
     pr_number: int,
     reviewer: str | None = None,
     repo: str | None = None,
     cwd: str | None = None,
+    ctx: Context | None = None,
 ) -> dict[str, list[str] | list[str]]:
     """Trigger a re-review for AI reviewers on a PR.
 
@@ -53,7 +55,8 @@ def request_rereview(
             if args:
                 gh.run_gh(*args, cwd=cwd)
                 triggered.append(adapter.name)
-                logger.info("Triggered re-review from %s on PR #%d", adapter.name, pr_number)
+                if ctx:
+                    await ctx.info(f"Triggered re-review from {adapter.name} on PR #{pr_number}")
         else:
             auto_triggers.append(adapter.name)
     else:
@@ -64,7 +67,8 @@ def request_rereview(
                 if args:
                     gh.run_gh(*args, cwd=cwd)
                     triggered.append(adapter.name)
-                    logger.info("Triggered re-review from %s on PR #%d", adapter.name, pr_number)
+                    if ctx:
+                        await ctx.info(f"Triggered re-review from {adapter.name} on PR #{pr_number}")
             else:
                 auto_triggers.append(adapter.name)
 

--- a/tests/test_rereview.py
+++ b/tests/test_rereview.py
@@ -18,8 +18,8 @@ class TestRequestRereview:
         mocker.patch("codereviewbuddy.tools.rereview.gh.get_repo_info", return_value=("owner", "repo"))
         self.mock_run = mocker.patch("codereviewbuddy.tools.rereview.gh.run_gh")
 
-    def test_trigger_unblocked(self):
-        result = request_rereview(42, reviewer="unblocked")
+    async def test_trigger_unblocked(self):
+        result = await request_rereview(42, reviewer="unblocked")
         assert "unblocked" in result["triggered"]
         assert result["auto_triggers"] == []
         self.mock_run.assert_called_once()
@@ -27,29 +27,29 @@ class TestRequestRereview:
         assert "42" in args
         assert "@unblocked please re-review" in args
 
-    def test_devin_auto_triggers(self):
-        result = request_rereview(42, reviewer="devin")
+    async def test_devin_auto_triggers(self):
+        result = await request_rereview(42, reviewer="devin")
         assert result["triggered"] == []
         assert "devin" in result["auto_triggers"]
 
-    def test_coderabbit_auto_triggers(self):
-        result = request_rereview(42, reviewer="coderabbit")
+    async def test_coderabbit_auto_triggers(self):
+        result = await request_rereview(42, reviewer="coderabbit")
         assert result["triggered"] == []
         assert "coderabbit" in result["auto_triggers"]
 
-    def test_trigger_all(self):
-        result = request_rereview(42)
+    async def test_trigger_all(self):
+        result = await request_rereview(42)
         assert "unblocked" in result["triggered"]
         assert "devin" in result["auto_triggers"]
         assert "coderabbit" in result["auto_triggers"]
 
-    def test_unknown_reviewer(self):
+    async def test_unknown_reviewer(self):
         with pytest.raises(ValueError, match="Unknown reviewer"):
-            request_rereview(42, reviewer="nonexistent")
+            await request_rereview(42, reviewer="nonexistent")
 
-    def test_explicit_repo(self, mocker: MockerFixture):
+    async def test_explicit_repo(self, mocker: MockerFixture):
         mock_run = mocker.patch("codereviewbuddy.tools.rereview.gh.run_gh")
-        result = request_rereview(42, reviewer="unblocked", repo="myorg/myrepo")
+        result = await request_rereview(42, reviewer="unblocked", repo="myorg/myrepo")
         assert "unblocked" in result["triggered"]
         args = mock_run.call_args[0]
         assert "myorg/myrepo" in args

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ ci = [
     { name = "pytest-cov", specifier = ">=6" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=3.15" },
-    { name = "ruff", specifier = ">=0.14" },
+    { name = "ruff", specifier = ">=0.15" },
     { name = "ty", specifier = ">=0.0.14" },
 ]
 docs = [


### PR DESCRIPTION
## Summary

Replace Python's `logging` module with FastMCP's `Context` object for structured logging and progress reporting visible to MCP clients.

Closes #5

## Changes

- **Async tool functions**: All tool functions in `server.py`, `comments.py`, and `rereview.py` are now `async def`
- **Progress reporting**: Paginated GraphQL fetches (review threads, stack PRs) report progress via `ctx.report_progress()`
- **Structured logging**: `ctx.info()` replaces `logger.info()` for thread counts, stale resolution, and re-review triggers
- **Context injection**: `get_context()` at the server tool level, passed as optional `ctx` parameter to utility functions
- **ruff 0.15 block suppressions**: `# ruff: disable[RUF029]` / `# ruff: enable[RUF029]` for async functions without internal awaits (`resolve_comment`, `reply_to_comment`)
- **Tests updated**: All unit tests converted to `async def` with `await`, using `AsyncMock` where needed

## Why async?

FastMCP Context methods (`ctx.info()`, `ctx.report_progress()`) are async. Making tools async enables MCP clients to see real-time progress during long paginated fetches instead of waiting silently.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
