### PR TITLE
feat: typed output schemas for tool responses (#6)

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 - Pydantic needs this at runtime
 from enum import StrEnum
-from typing import TypedDict
 
 from pydantic import BaseModel, Field
 
@@ -57,9 +56,16 @@ class StackStatus(BaseModel):
     stack_tool: str = Field(default="none", description="Stack tool detected (graphite, git-town, none)")
 
 
-class ResolveStaleResult(TypedDict):
+class ResolveStaleResult(BaseModel):
     """Result of bulk-resolving stale review threads."""
 
-    resolved_count: int
-    resolved_thread_ids: list[str]
-    skipped_count: int
+    resolved_count: int = Field(description="Number of threads resolved")
+    resolved_thread_ids: list[str] = Field(default_factory=list, description="Thread IDs that were resolved")
+    skipped_count: int = Field(default=0, description="Threads skipped because the reviewer auto-resolves (e.g. Devin, CodeRabbit)")
+
+
+class RereviewResult(BaseModel):
+    """Result of triggering re-reviews on a PR."""
+
+    triggered: list[str] = Field(default_factory=list, description="Reviewers that were manually triggered")
+    auto_triggers: list[str] = Field(default_factory=list, description="Reviewers that auto-trigger on push (no action needed)")

--- a/src/codereviewbuddy/tools/rereview.py
+++ b/src/codereviewbuddy/tools/rereview.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from codereviewbuddy import gh
+from codereviewbuddy.models import RereviewResult
 from codereviewbuddy.reviewers import REVIEWERS, get_reviewer
 
 if TYPE_CHECKING:
@@ -17,7 +18,7 @@ async def request_rereview(
     repo: str | None = None,
     cwd: str | None = None,
     ctx: Context | None = None,
-) -> dict[str, list[str] | list[str]]:
+) -> RereviewResult:
     """Trigger a re-review for AI reviewers on a PR.
 
     For reviewers that need manual triggering (e.g. Unblocked), posts a comment.
@@ -72,4 +73,4 @@ async def request_rereview(
             else:
                 auto_triggers.append(adapter.name)
 
-    return {"triggered": triggered, "auto_triggers": auto_triggers}
+    return RereviewResult(triggered=triggered, auto_triggers=auto_triggers)

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -245,8 +245,8 @@ class TestResolveStaleComments:
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         result = await resolve_stale_comments(42)
-        assert result["resolved_count"] == 1
-        assert "PRRT_kwDOtest123" in result["resolved_thread_ids"]
+        assert result.resolved_count == 1
+        assert "PRRT_kwDOtest123" in result.resolved_thread_ids
 
     async def test_skips_auto_resolving_reviewers(self, mocker: MockerFixture):
         """Devin/CodeRabbit threads should be skipped — they auto-resolve themselves."""
@@ -292,10 +292,10 @@ class TestResolveStaleComments:
 
         result = await resolve_stale_comments(42)
         # Only the unblocked thread should be resolved; Devin thread skipped
-        assert result["resolved_count"] == 1
-        assert "PRRT_kwDOtest123" in result["resolved_thread_ids"]
-        assert "PRRT_kwDOdevin456" not in result["resolved_thread_ids"]
-        assert result["skipped_count"] == 1
+        assert result.resolved_count == 1
+        assert "PRRT_kwDOtest123" in result.resolved_thread_ids
+        assert "PRRT_kwDOdevin456" not in result.resolved_thread_ids
+        assert result.skipped_count == 1
 
     async def test_nothing_to_resolve(self, mocker: MockerFixture):
         no_diff = {
@@ -318,7 +318,7 @@ class TestResolveStaleComments:
         mocker.patch("codereviewbuddy.tools.comments.gh.get_repo_info", return_value=("owner", "repo"))
 
         result = await resolve_stale_comments(42)
-        assert result["resolved_count"] == 0
+        assert result.resolved_count == 0
 
 
 class TestGetPrReviews:

--- a/tests/test_rereview.py
+++ b/tests/test_rereview.py
@@ -20,8 +20,8 @@ class TestRequestRereview:
 
     async def test_trigger_unblocked(self):
         result = await request_rereview(42, reviewer="unblocked")
-        assert "unblocked" in result["triggered"]
-        assert result["auto_triggers"] == []
+        assert "unblocked" in result.triggered
+        assert result.auto_triggers == []
         self.mock_run.assert_called_once()
         args = self.mock_run.call_args[0]
         assert "42" in args
@@ -29,19 +29,19 @@ class TestRequestRereview:
 
     async def test_devin_auto_triggers(self):
         result = await request_rereview(42, reviewer="devin")
-        assert result["triggered"] == []
-        assert "devin" in result["auto_triggers"]
+        assert result.triggered == []
+        assert "devin" in result.auto_triggers
 
     async def test_coderabbit_auto_triggers(self):
         result = await request_rereview(42, reviewer="coderabbit")
-        assert result["triggered"] == []
-        assert "coderabbit" in result["auto_triggers"]
+        assert result.triggered == []
+        assert "coderabbit" in result.auto_triggers
 
     async def test_trigger_all(self):
         result = await request_rereview(42)
-        assert "unblocked" in result["triggered"]
-        assert "devin" in result["auto_triggers"]
-        assert "coderabbit" in result["auto_triggers"]
+        assert "unblocked" in result.triggered
+        assert "devin" in result.auto_triggers
+        assert "coderabbit" in result.auto_triggers
 
     async def test_unknown_reviewer(self):
         with pytest.raises(ValueError, match="Unknown reviewer"):
@@ -50,6 +50,6 @@ class TestRequestRereview:
     async def test_explicit_repo(self, mocker: MockerFixture):
         mock_run = mocker.patch("codereviewbuddy.tools.rereview.gh.run_gh")
         result = await request_rereview(42, reviewer="unblocked", repo="myorg/myrepo")
-        assert "unblocked" in result["triggered"]
+        assert "unblocked" in result.triggered
         args = mock_run.call_args[0]
         assert "myorg/myrepo" in args


### PR DESCRIPTION
## Summary

Use FastMCP's `output_schema` feature to return typed Pydantic models from MCP tools instead of raw dicts. Agents now see exact response shapes in tool schemas, enabling type validation and better IDE/client integration.

Closes #6

## Changes

- **`ResolveStaleResult`**: Converted from `TypedDict` to `BaseModel` with `Field` descriptions
- **`RereviewResult`**: New Pydantic model for `request_rereview` responses (replaces `dict[str, list[str]]`)
- **Server tools return models directly**: `list[ReviewThread]`, `ResolveStaleResult`, `RereviewResult` — no more `model_dump()` in `server.py`
- **FastMCP auto-generates `outputSchema`** from return type annotations — agents see field names, types, and descriptions
- **Integration tests**: Verify `outputSchema` presence and field names for `resolve_stale_comments` and `request_rereview`

## Before / After

**Before**: Tools returned `list[dict]` or `dict` — agents had to guess the response shape.

**After**: Tools declare typed return annotations. FastMCP exposes JSON schemas like:

```json
{
  "type": "object",
  "properties": {
    "resolved_count": {"type": "integer", "description": "Number of threads resolved"},
    "resolved_thread_ids": {"type": "array", "items": {"type": "string"}, "description": "Thread IDs that were resolved"}
  }
}
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
