### PR TITLE
refactor: wrap blocking gh.* calls to stop blocking the event loop (#37)

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -108,7 +108,7 @@ async def list_stack_review_comments(
 
 
 @mcp.tool
-async def resolve_comment(
+def resolve_comment(
     pr_number: int,
     thread_id: str,
 ) -> str:
@@ -121,7 +121,7 @@ async def resolve_comment(
         pr_number: PR number (for context).
         thread_id: The GraphQL node ID (PRRT_...) of the thread to resolve.
     """
-    return await comments.resolve_comment(pr_number, thread_id)
+    return comments.resolve_comment(pr_number, thread_id)
 
 
 @mcp.tool
@@ -146,7 +146,7 @@ async def resolve_stale_comments(
 
 
 @mcp.tool
-async def reply_to_comment(
+def reply_to_comment(
     pr_number: int,
     thread_id: str,
     body: str,
@@ -160,7 +160,7 @@ async def reply_to_comment(
         body: Reply text.
         repo: Repository in "owner/repo" format. Auto-detected if not provided.
     """
-    return await comments.reply_to_comment(pr_number, thread_id, body, repo=repo)
+    return comments.reply_to_comment(pr_number, thread_id, body, repo=repo)
 
 
 @mcp.tool

--- a/src/codereviewbuddy/tools/rereview.py
+++ b/src/codereviewbuddy/tools/rereview.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from fastmcp.utilities.async_utils import call_sync_fn_in_threadpool
+
 from codereviewbuddy import gh
 from codereviewbuddy.models import RereviewResult
 from codereviewbuddy.reviewers import REVIEWERS, get_reviewer
@@ -39,7 +41,7 @@ async def request_rereview(
     if repo:
         owner, repo_name = repo.split("/", 1)
     else:
-        owner, repo_name = gh.get_repo_info(cwd=cwd)
+        owner, repo_name = await call_sync_fn_in_threadpool(gh.get_repo_info, cwd=cwd)
 
     triggered: list[str] = []
     auto_triggers: list[str] = []
@@ -54,7 +56,7 @@ async def request_rereview(
         if adapter.needs_manual_rereview:
             args = adapter.rereview_trigger(pr_number, owner, repo_name)
             if args:
-                gh.run_gh(*args, cwd=cwd)
+                await call_sync_fn_in_threadpool(gh.run_gh, *args, cwd=cwd)
                 triggered.append(adapter.name)
                 if ctx:
                     await ctx.info(f"Triggered re-review from {adapter.name} on PR #{pr_number}")
@@ -66,7 +68,7 @@ async def request_rereview(
             if adapter.needs_manual_rereview:
                 args = adapter.rereview_trigger(pr_number, owner, repo_name)
                 if args:
-                    gh.run_gh(*args, cwd=cwd)
+                    await call_sync_fn_in_threadpool(gh.run_gh, *args, cwd=cwd)
                     triggered.append(adapter.name)
                     if ctx:
                         await ctx.info(f"Triggered re-review from {adapter.name} on PR #{pr_number}")

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -217,14 +217,14 @@ class TestResolveComment:
     async def test_success(self, mocker: MockerFixture):
         response = {"data": {"resolveReviewThread": {"thread": {"id": "PRRT_test", "isResolved": True}}}}
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=response)
-        result = await resolve_comment(42, "PRRT_test")
+        result = resolve_comment(42, "PRRT_test")
         assert "Resolved" in result
 
     async def test_failure(self, mocker: MockerFixture):
         response = {"data": {"resolveReviewThread": {"thread": {"id": "PRRT_test", "isResolved": False}}}}
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=response)
         with pytest.raises(GhError, match="Failed to resolve"):
-            await resolve_comment(42, "PRRT_test")
+            resolve_comment(42, "PRRT_test")
 
 
 class TestResolveStaleComments:


### PR DESCRIPTION
## Summary

Wraps all blocking `gh.*` subprocess calls to stop blocking the event loop in async MCP tool functions (closes #37).

## Strategy

Two-pronged approach leveraging FastMCP v3 (PR #38):

### Group 1: Convert to sync (FastMCP auto-threadpools)

`resolve_comment` and `reply_to_comment` had zero `await` expressions (ruff flagged them with `RUF029`). Converted from `async def` → `def` in both `comments.py` and `server.py`. FastMCP automatically runs sync tool functions in a threadpool.

### Group 2: Wrap with `call_sync_fn_in_threadpool`

Functions that must stay `async def` for `ctx.report_progress()`/`ctx.info()` now wrap blocking calls:

- **`comments.py`**: `gh.get_repo_info()`, `gh.graphql()` (pagination loop), `_get_changed_files()`, `_get_pr_reviews()`, batch mutation
- **`rereview.py`**: `gh.get_repo_info()`, `gh.run_gh()` (2 call sites)

Uses FastMCP's `call_sync_fn_in_threadpool` from `fastmcp.utilities.async_utils` — wraps `anyio.to_thread.run_sync()` with proper contextvars propagation.

## Depends on

- PR #38 — FastMCP v3 upgrade (provides `call_sync_fn_in_threadpool`)

## Test results

96 tests pass, 97.9% coverage. One test updated to remove `await` from now-sync `resolve_comment`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
