### PR TITLE
feat: add create_issue_from_comment tool to track useful review suggestions (#40)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -13,6 +13,9 @@ exclude = [
     '^mailto:',
     # Private repo — various URLs 404 without auth
     '^https://github\.com/detailobsessed/codereviewbuddy',
+    # Placeholder URLs used in test fixtures
+    '^https://github\.com/owner/repo',
+    '^https://github\.com/other/repo',
     '^https://detailobsessed\.github\.io/codereviewbuddy',
     # Local dev server referenced in CONTRIBUTING.md
     '^http://localhost',

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -78,3 +78,11 @@ class UpdateCheckResult(BaseModel):
     latest_version: str = Field(description="Latest version on PyPI, or 'unknown' if check failed")
     update_available: bool = Field(description="Whether a newer version is available")
     upgrade_command: str = Field(default="uvx --upgrade codereviewbuddy", description="Command to upgrade")
+
+
+class CreateIssueResult(BaseModel):
+    """Result of creating a GitHub issue from a review comment."""
+
+    issue_number: int = Field(description="Created issue number")
+    issue_url: str = Field(description="URL of the created issue")
+    title: str = Field(description="Issue title")

--- a/src/codereviewbuddy/tools/issues.py
+++ b/src/codereviewbuddy/tools/issues.py
@@ -1,0 +1,125 @@
+"""MCP tool for creating GitHub issues from review comments."""
+
+from __future__ import annotations
+
+import logging
+
+from codereviewbuddy import gh
+from codereviewbuddy.models import CreateIssueResult
+
+logger = logging.getLogger(__name__)
+
+_THREAD_QUERY = """
+query($threadId: ID!) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 1) {
+        nodes {
+          body
+          path
+          line
+          author { login }
+          url
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def create_issue_from_comment(
+    pr_number: int,
+    thread_id: str,
+    title: str,
+    labels: list[str] | None = None,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> CreateIssueResult:
+    """Create a GitHub issue from a review comment thread.
+
+    Args:
+        pr_number: PR number the comment belongs to.
+        thread_id: GraphQL node ID (PRRT_...) of the review thread.
+        title: Issue title.
+        labels: Optional labels to apply (e.g. ["enhancement", "P2"]).
+        repo: Repository in "owner/repo" format. Auto-detected if not provided.
+        cwd: Working directory.
+
+    Returns:
+        Created issue number, URL, and title.
+    """
+    if repo:
+        owner, repo_name = repo.split("/", 1)
+    else:
+        owner, repo_name = gh.get_repo_info(cwd=cwd)
+
+    full_repo = f"{owner}/{repo_name}"
+
+    # Fetch the thread content
+    result = gh.graphql(_THREAD_QUERY, variables={"threadId": thread_id}, cwd=cwd)
+    node = result.get("data", {}).get("node") or {}
+    comment_nodes = node.get("comments", {}).get("nodes", [])
+
+    if not comment_nodes:
+        msg = f"Could not find comment content for thread {thread_id}"
+        raise gh.GhError(msg)
+
+    comment = comment_nodes[0]
+    body_text = comment.get("body", "")
+    file_path = comment.get("path")
+    line = comment.get("line")
+    author = (comment.get("author") or {}).get("login", "unknown")
+    comment_url = comment.get("url", "")
+
+    # Build issue body
+    parts = [f"From review comment on PR #{pr_number}"]
+    if comment_url:
+        parts[0] = f"From [review comment]({comment_url}) on PR #{pr_number}"
+
+    if file_path:
+        location = f"`{file_path}`"
+        if line:
+            location += f" line {line}"
+        parts.append(f"**Location:** {location}")
+
+    parts.extend([
+        f"**Reviewer:** {author}",
+        "",
+        f"> {body_text.replace(chr(10), chr(10) + '> ')}",
+    ])
+
+    issue_body = "\n\n".join(parts)
+
+    # Create issue via gh CLI
+    args = [
+        "issue",
+        "create",
+        "--repo",
+        full_repo,
+        "--title",
+        title,
+        "--body",
+        issue_body,
+    ]
+    if labels:
+        for label in labels:
+            args.extend(["--label", label])
+
+    raw = gh.run_gh(*args, cwd=cwd)
+
+    # Parse the issue URL from output (gh issue create prints the URL)
+    issue_url = raw.strip()
+
+    # Extract issue number from URL (e.g. https://github.com/owner/repo/issues/42)
+    try:
+        issue_number = int(issue_url.rstrip("/").split("/")[-1])
+    except ValueError, IndexError:
+        logger.warning("Could not parse issue number from: %s", issue_url)
+        issue_number = 0
+
+    return CreateIssueResult(
+        issue_number=issue_number,
+        issue_url=issue_url,
+        title=title,
+    )

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,177 @@
+"""Tests for issue creation tool."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from codereviewbuddy.gh import GhError
+from codereviewbuddy.tools.issues import create_issue_from_comment
+
+SAMPLE_THREAD_RESPONSE = {
+    "data": {
+        "node": {
+            "comments": {
+                "nodes": [
+                    {
+                        "body": "Consider refactoring this into a helper function.",
+                        "path": "src/codereviewbuddy/tools/comments.py",
+                        "line": 42,
+                        "author": {"login": "unblocked[bot]"},
+                        "url": "https://github.com/owner/repo/pull/10#discussion_r123",
+                    }
+                ]
+            }
+        }
+    },
+}
+
+
+class TestCreateIssueFromComment:
+    def test_creates_issue_with_labels(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.issues.gh.get_repo_info", return_value=("owner", "repo"))
+        mock_graphql = mocker.patch("codereviewbuddy.tools.issues.gh.graphql", return_value=SAMPLE_THREAD_RESPONSE)
+        mock_run_gh = mocker.patch(
+            "codereviewbuddy.tools.issues.gh.run_gh",
+            return_value="https://github.com/owner/repo/issues/42\n",
+        )
+
+        result = create_issue_from_comment(
+            pr_number=10,
+            thread_id="PRRT_kwDOtest123",
+            title="Refactor into helper function",
+            labels=["enhancement", "P2"],
+        )
+
+        assert result.issue_number == 42
+        assert result.issue_url == "https://github.com/owner/repo/issues/42"
+        assert result.title == "Refactor into helper function"
+
+        # Verify gh issue create was called with correct args
+        call_args = mock_run_gh.call_args[0]
+        assert "issue" in call_args
+        assert "create" in call_args
+        assert "--label" in call_args
+        assert "enhancement" in call_args
+        assert "P2" in call_args
+
+        # Verify thread was fetched
+        mock_graphql.assert_called_once()
+
+    def test_creates_issue_without_labels(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.issues.gh.get_repo_info", return_value=("owner", "repo"))
+        mocker.patch("codereviewbuddy.tools.issues.gh.graphql", return_value=SAMPLE_THREAD_RESPONSE)
+        mock_run_gh = mocker.patch(
+            "codereviewbuddy.tools.issues.gh.run_gh",
+            return_value="https://github.com/owner/repo/issues/7\n",
+        )
+
+        result = create_issue_from_comment(
+            pr_number=10,
+            thread_id="PRRT_kwDOtest123",
+            title="Track suggestion",
+        )
+
+        assert result.issue_number == 7
+        call_args = mock_run_gh.call_args[0]
+        assert "--label" not in call_args
+
+    def test_explicit_repo(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.issues.gh.graphql", return_value=SAMPLE_THREAD_RESPONSE)
+        mock_run_gh = mocker.patch(
+            "codereviewbuddy.tools.issues.gh.run_gh",
+            return_value="https://github.com/other/repo/issues/1\n",
+        )
+
+        result = create_issue_from_comment(
+            pr_number=5,
+            thread_id="PRRT_kwDOtest456",
+            title="Test",
+            repo="other/repo",
+        )
+
+        assert result.issue_number == 1
+        call_args = mock_run_gh.call_args[0]
+        assert "other/repo" in call_args
+
+    def test_thread_not_found_raises(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.issues.gh.get_repo_info", return_value=("owner", "repo"))
+        mocker.patch(
+            "codereviewbuddy.tools.issues.gh.graphql",
+            return_value={"data": {"node": {"comments": {"nodes": []}}}},
+        )
+
+        with pytest.raises(GhError, match="Could not find comment content"):
+            create_issue_from_comment(
+                pr_number=10,
+                thread_id="PRRT_kwDObad",
+                title="Should fail",
+            )
+
+    def test_issue_body_contains_pr_reference(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.tools.issues.gh.get_repo_info", return_value=("owner", "repo"))
+        mocker.patch("codereviewbuddy.tools.issues.gh.graphql", return_value=SAMPLE_THREAD_RESPONSE)
+        mock_run_gh = mocker.patch(
+            "codereviewbuddy.tools.issues.gh.run_gh",
+            return_value="https://github.com/owner/repo/issues/5\n",
+        )
+
+        create_issue_from_comment(
+            pr_number=10,
+            thread_id="PRRT_kwDOtest123",
+            title="Test body content",
+        )
+
+        # Extract the --body argument
+        call_args = mock_run_gh.call_args[0]
+        body_idx = list(call_args).index("--body") + 1
+        body = call_args[body_idx]
+
+        assert "PR #10" in body
+        assert "src/codereviewbuddy/tools/comments.py" in body
+        assert "line 42" in body
+        assert "unblocked[bot]" in body
+        assert "Consider refactoring" in body
+
+    def test_comment_without_file_path(self, mocker: MockerFixture):
+        """PR-level comments may not have a file path."""
+        response = {
+            "data": {
+                "node": {
+                    "comments": {
+                        "nodes": [
+                            {
+                                "body": "General improvement suggestion.",
+                                "path": None,
+                                "line": None,
+                                "author": {"login": "devin-ai-integration[bot]"},
+                                "url": "https://github.com/owner/repo/pull/3#discussion_r789",
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+        mocker.patch("codereviewbuddy.tools.issues.gh.get_repo_info", return_value=("owner", "repo"))
+        mocker.patch("codereviewbuddy.tools.issues.gh.graphql", return_value=response)
+        mock_run_gh = mocker.patch(
+            "codereviewbuddy.tools.issues.gh.run_gh",
+            return_value="https://github.com/owner/repo/issues/99\n",
+        )
+
+        result = create_issue_from_comment(
+            pr_number=3,
+            thread_id="PRRT_kwDOtest789",
+            title="General suggestion",
+        )
+
+        assert result.issue_number == 99
+        # Body should not contain file location
+        call_args = mock_run_gh.call_args[0]
+        body_idx = list(call_args).index("--body") + 1
+        body = call_args[body_idx]
+        assert "**Location:**" not in body

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -118,6 +118,7 @@ class TestToolRegistration:
         "reply_to_comment",
         "request_rereview",
         "check_for_updates",
+        "create_issue_from_comment",
     })
 
     async def test_all_tools_registered(self, client: Client):
@@ -127,7 +128,7 @@ class TestToolRegistration:
 
     async def test_tool_count(self, client: Client):
         tools = await client.list_tools()
-        assert len(tools) == 7
+        assert len(tools) == 8
 
     async def test_list_review_comments_schema(self, client: Client):
         tools = await client.list_tools()


### PR DESCRIPTION
## Summary

Adds a `create_issue_from_comment` tool that creates GitHub issues from noteworthy AI review comments (closes #40).

## How it works

1. Agent calls `create_issue_from_comment` with a thread ID, title, and optional labels
2. Tool fetches the thread content (body, file, line, author, URL) via GraphQL
3. Builds a formatted issue body with:
   - Link back to the PR comment
   - File/line reference
   - Reviewer attribution
   - Quoted comment text
4. Creates the issue via `gh issue create` with the specified labels

## Design: agent-driven labels

The agent picks labels based on context it already has from `list_review_comments`. No hardcoded severity→label mapping — works with any repo's label scheme. The repo has type labels (`bug`, `enhancement`, `documentation`) and priority labels (`P0`–`P3`).

## Server instruction update

Added a "Tracking useful suggestions" section guiding the agent to file issues for genuinely useful non-bug suggestions, and to skip nitpicks or things being fixed in the PR.

## Files

- `src/codereviewbuddy/models.py` — `CreateIssueResult` model
- `src/codereviewbuddy/tools/issues.py` — new module with implementation
- `src/codereviewbuddy/server.py` — tool registration + instruction update
- `tests/test_issues.py` — 6 tests covering labels, no labels, explicit repo, thread not found, body content, and no file path
- `tests/test_mcp_integration.py` — tool count bumped to 8
- `.lychee.toml` — exclude placeholder URLs in test fixtures

## Test results

102 tests pass, 97.7% coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
