### PR TITLE
fix: support PRR_ IDs in reply_to_comment for PR-level reviews (#42)

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -167,11 +167,13 @@ def reply_to_comment(
     body: str,
     repo: str | None = None,
 ) -> str:
-    """Reply to a specific review thread.
+    """Reply to a specific review thread or PR-level review.
+
+    Supports both inline review threads (PRRT_ IDs) and PR-level reviews (PRR_ IDs).
 
     Args:
         pr_number: PR number.
-        thread_id: The GraphQL node ID (PRRT_...) of the thread to reply to.
+        thread_id: The GraphQL node ID (PRRT_... or PRR_...) of the thread to reply to.
         body: Reply text.
         repo: Repository in "owner/repo" format. Auto-detected if not provided.
     """


### PR DESCRIPTION
## Summary

Fixes `reply_to_comment` to support PR-level review threads (`PRR_` IDs), not just inline review threads (`PRRT_` IDs). Closes #42.

## Problem

`reply_to_comment` used a GraphQL query with `... on PullRequestReviewThread` which doesn't match `PullRequestReview` nodes. When given a `PRR_` ID, it returned:
```
Could not find comment ID for thread PRR_kwDO...
```

## Fix

Detect the ID prefix and route to the appropriate API:
- **`PRRT_`** → existing flow: get comment `databaseId` via GraphQL → REST reply to pull review comment
- **`PRR_`** → new: POST to `/repos/{owner}/{repo}/issues/{pr}/comments` (issues comments API)

Refactored into two private helpers: `_reply_to_review_thread` and `_reply_to_pr_review`.

## Tests

4 new tests: inline thread reply, PR-level review reply, explicit repo, and thread-not-found error.
111 tests pass, 98.1% coverage. `comments.py` at 100%.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
