### PR TITLE
feat: surface bot PR comments (codecov, netlify, etc.) in list_review_comments (#24)

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -167,13 +167,14 @@ def reply_to_comment(
     body: str,
     repo: str | None = None,
 ) -> str:
-    """Reply to a specific review thread or PR-level review.
+    """Reply to a specific review thread, PR-level review, or bot comment.
 
-    Supports both inline review threads (PRRT_ IDs) and PR-level reviews (PRR_ IDs).
+    Supports inline review threads (PRRT_ IDs), PR-level reviews (PRR_ IDs),
+    and issue comments (IC_ IDs, e.g. bot comments from codecov/netlify).
 
     Args:
         pr_number: PR number.
-        thread_id: The GraphQL node ID (PRRT_... or PRR_...) of the thread to reply to.
+        thread_id: The node ID (PRRT_..., PRR_..., or IC_...) to reply to.
         body: Reply text.
         repo: Repository in "owner/repo" format. Auto-detected if not provided.
     """


### PR DESCRIPTION
## Summary

Surfaces regular PR comments from bots (codecov, netlify, vercel, etc.) in `list_review_comments` results. Closes #24.

## Problem

Bot comments posted as `IssueComment` nodes (not review threads or PR reviews) were invisible to `list_review_comments`. Users asking "are there any comments on my PR?" got empty results even when bot feedback existed.

## Fix

New helper `_get_pr_issue_comments` fetches `/repos/{owner}/{repo}/issues/{pr}/comments` and includes comments from bots (identified by `user.type == 'Bot'` or login ending with `[bot]`). Human comments are excluded to avoid noise.

Bot comments appear as `ReviewThread` objects with `is_pr_review=True`, making them visible alongside inline threads and AI reviewer summaries.

Known AI reviewers (unblocked, devin, coderabbit) use their reviewer name; unknown bots use their login as the reviewer field.

## Tests

5 new tests: bot comments included, human comments excluded, empty bodies skipped, empty response, known reviewer name mapping.
111 tests pass, 98.2% coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
