### PR TITLE
ci: add pull-requests read permission for dorny/paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ name: ci
     branches:
     - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Problem

The `dorny/paths-filter@v3` action in the CI workflow fails with `Resource not accessible by integration` on `pull_request` events. This has been broken for all PRs — the `changes` job cannot query the GitHub API for PR changed files because the default `GITHUB_TOKEN` lacks the required permission on Blacksmith runners.

The `push` event CI on `main` is unaffected (paths-filter falls back to `git diff`), which is why this went unnoticed until now.

## Fix

Add explicit `permissions` block to the CI workflow:

```yaml
permissions:
  contents: read
  pull-requests: read
```

`pull-requests: read` allows `dorny/paths-filter` to call the GitHub API to list changed files for PRs. `contents: read` is included explicitly since setting any permission resets all others to `none`.

## Verification

If this fix works, the CI run on this very PR will pass the `changes` job (which has been failing on every PR in the repo).