### PR TITLE
docs: fix uvx config to handle fastmcp v3 pre-release dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,15 @@ Add to your MCP settings (`~/.codeium/windsurf/mcp_config.json`):
   "mcpServers": {
     "codereviewbuddy": {
       "command": "uvx",
-      "args": ["codereviewbuddy"]
+      "args": ["--prerelease=allow", "codereviewbuddy@latest"]
     }
   }
 }
 ```
+
+> **Why `--prerelease=allow`?** codereviewbuddy depends on FastMCP v3 beta (`>=3.0.0b2`). Without this flag, `uvx` refuses to resolve pre-release dependencies.
+>
+> **Why `@latest`?** Without it, `uvx` caches the first resolved version and never upgrades automatically.
 
 ### Claude Desktop
 
@@ -98,7 +102,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "codereviewbuddy": {
       "command": "uvx",
-      "args": ["codereviewbuddy"]
+      "args": ["--prerelease=allow", "codereviewbuddy@latest"]
     }
   }
 }
@@ -113,7 +117,7 @@ Add to `.cursor/mcp.json` in your project:
   "mcpServers": {
     "codereviewbuddy": {
       "command": "uvx",
-      "args": ["codereviewbuddy"]
+      "args": ["--prerelease=allow", "codereviewbuddy@latest"]
     }
   }
 }


### PR DESCRIPTION
## Problem

`uvx codereviewbuddy` fails to resolve dependencies because FastMCP v3 is a pre-release (`>=3.0.0b2`) and `uvx` refuses pre-releases by default:

```
Because only fastmcp<3.0.0b2 is available and codereviewbuddy==0.8.0
depends on fastmcp>=3.0.0b2, we can conclude that your requirements
are unsatisfiable.

hint: fastmcp was requested with a pre-release marker, but pre-releases
were not enabled (try: --prerelease=allow)
```

Additionally, `uvx` caches resolved environments and never upgrades unless explicitly told to.

## Fix

Update all MCP client config examples in the README to use:

```json
"args": ["--prerelease=allow", "codereviewbuddy@latest"]
```

- **`--prerelease=allow`** — required because we depend on FastMCP v3 beta
- **`@latest`** — forces `uvx` to always resolve the latest PyPI version instead of using its cache

Added an explanatory callout below the first config example so users understand why these flags are needed.