### PR TITLE
feat: detect in-progress AI reviews and add wait_for_reviews tool (#46, #4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,4 @@ jobs:
   mcp-registry-publish:
     needs: release
     if: needs.release.outputs.released == 'true'
-    uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish-bun.yml@main
+    uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish.yml@main

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -37,6 +37,26 @@ class ReviewThread(BaseModel):
     is_pr_review: bool = Field(default=False, description="True for PR-level reviews (PRR_ IDs) — not resolvable via resolveReviewThread")
 
 
+class ReviewerStatus(BaseModel):
+    """Status of a specific AI reviewer on a PR."""
+
+    reviewer: str = Field(description="Reviewer name (e.g. 'devin', 'unblocked')")
+    status: str = Field(description="'completed' (reviewed latest push) or 'pending' (push after last review)")
+    detail: str = Field(description="Human-readable explanation of the status")
+    last_review_at: datetime | None = Field(default=None, description="Timestamp of the reviewer's most recent comment/review")
+    last_push_at: datetime | None = Field(default=None, description="Timestamp of the latest commit on the PR")
+
+
+class ReviewSummary(BaseModel):
+    """Review threads plus reviewer status for a PR."""
+
+    threads: list[ReviewThread] = Field(default_factory=list, description="All review threads on the PR")
+    reviewer_statuses: list[ReviewerStatus] = Field(default_factory=list, description="Per-reviewer status based on timestamp heuristic")
+    reviews_in_progress: bool = Field(
+        default=False, description="True if at least one reviewer has a pending review (pushed after last review)"
+    )
+
+
 class StackPR(BaseModel):
     """A PR in a stack with review summary."""
 

--- a/src/codereviewbuddy/tools/wait.py
+++ b/src/codereviewbuddy/tools/wait.py
@@ -1,0 +1,76 @@
+"""MCP tool for waiting until AI reviews complete."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from codereviewbuddy.models import ReviewSummary  # noqa: TC001 - runtime needed
+from codereviewbuddy.tools.comments import list_review_comments
+
+if TYPE_CHECKING:
+    from fastmcp.server.context import Context
+
+
+async def wait_for_reviews(
+    pr_number: int,
+    repo: str | None = None,
+    timeout: int = 300,
+    poll_interval: int = 30,
+    cwd: str | None = None,
+    ctx: Context | None = None,
+) -> ReviewSummary:
+    """Poll until all known AI reviewers have reviewed the latest push.
+
+    Repeatedly calls list_review_comments and checks reviews_in_progress.
+    Returns when all reviewers have completed or timeout is reached.
+
+    Args:
+        pr_number: PR number to monitor.
+        repo: Repository in "owner/repo" format. Auto-detected if not provided.
+        timeout: Maximum seconds to wait (default 300 = 5 minutes).
+        poll_interval: Seconds between polls (default 30).
+        cwd: Working directory for git operations.
+        ctx: FastMCP context for progress reporting.
+
+    Returns:
+        Final ReviewSummary (reviews may still be in progress if timeout was reached).
+    """
+    if poll_interval <= 0:
+        msg = f"poll_interval must be positive, got {poll_interval}"
+        raise ValueError(msg)
+    if timeout < 0:
+        msg = f"timeout must be non-negative, got {timeout}"
+        raise ValueError(msg)
+
+    elapsed = 0
+    poll_count = 0
+    max_polls = timeout // poll_interval + 1  # +1 for the initial poll at t=0
+
+    while True:
+        poll_count += 1
+        if ctx:
+            await ctx.report_progress(progress=poll_count, total=max_polls)
+            await ctx.info(f"Polling for reviews on PR #{pr_number} ({poll_count}/{max_polls})")
+
+        summary = await list_review_comments(pr_number, repo=repo, cwd=cwd, ctx=None)
+
+        if not summary.reviews_in_progress:
+            if ctx:
+                await ctx.info(f"All reviews complete on PR #{pr_number}")
+            return summary
+
+        if elapsed + poll_interval > timeout:
+            if ctx:
+                pending = [s.reviewer for s in summary.reviewer_statuses if s.status == "pending"]
+                await ctx.warning(
+                    f"Timeout after {elapsed}s waiting for reviews on PR #{pr_number}. Still pending: {', '.join(pending)}",
+                )
+            return summary
+
+        if ctx:
+            pending = [s.reviewer for s in summary.reviewer_statuses if s.status == "pending"]
+            await ctx.info(f"Waiting {poll_interval}s... pending: {', '.join(pending)}")
+
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -119,6 +119,7 @@ class TestToolRegistration:
         "request_rereview",
         "check_for_updates",
         "create_issue_from_comment",
+        "wait_for_reviews",
     })
 
     async def test_all_tools_registered(self, client: Client):
@@ -128,7 +129,7 @@ class TestToolRegistration:
 
     async def test_tool_count(self, client: Client):
         tools = await client.list_tools()
-        assert len(tools) == 8
+        assert len(tools) == 9
 
     async def test_list_review_comments_schema(self, client: Client):
         tools = await client.list_tools()

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,125 @@
+"""Tests for the wait_for_reviews tool."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from codereviewbuddy.models import ReviewerStatus, ReviewSummary
+from codereviewbuddy.tools.wait import wait_for_reviews
+
+
+class TestWaitForReviews:
+    async def test_returns_immediately_when_no_reviews_in_progress(self, mocker: MockerFixture):
+        summary = ReviewSummary(threads=[], reviews_in_progress=False)
+
+        from unittest.mock import AsyncMock
+
+        mocker.patch(
+            "codereviewbuddy.tools.wait.list_review_comments",
+            new_callable=AsyncMock,
+            return_value=summary,
+        )
+
+        result = await wait_for_reviews(42, repo="owner/repo", timeout=60, poll_interval=10)
+        assert result.reviews_in_progress is False
+
+    async def test_polls_until_reviews_complete(self, mocker: MockerFixture):
+        pending_summary = ReviewSummary(
+            threads=[],
+            reviewer_statuses=[
+                ReviewerStatus(
+                    reviewer="devin",
+                    status="pending",
+                    detail="devin has not reviewed since latest push",
+                ),
+            ],
+            reviews_in_progress=True,
+        )
+        completed_summary = ReviewSummary(
+            threads=[],
+            reviewer_statuses=[
+                ReviewerStatus(
+                    reviewer="devin",
+                    status="completed",
+                    detail="devin reviewed after latest push",
+                ),
+            ],
+            reviews_in_progress=False,
+        )
+
+        from unittest.mock import AsyncMock
+
+        mock_list = mocker.patch(
+            "codereviewbuddy.tools.wait.list_review_comments",
+            new_callable=AsyncMock,
+            side_effect=[pending_summary, completed_summary],
+        )
+        mocker.patch("codereviewbuddy.tools.wait.asyncio.sleep", new_callable=AsyncMock)
+
+        result = await wait_for_reviews(42, repo="owner/repo", timeout=120, poll_interval=30)
+        assert result.reviews_in_progress is False
+        assert mock_list.call_count == 2
+
+    async def test_returns_on_timeout(self, mocker: MockerFixture):
+        pending_summary = ReviewSummary(
+            threads=[],
+            reviewer_statuses=[
+                ReviewerStatus(
+                    reviewer="unblocked",
+                    status="pending",
+                    detail="unblocked has not reviewed since latest push",
+                ),
+            ],
+            reviews_in_progress=True,
+        )
+
+        from unittest.mock import AsyncMock
+
+        mock_list = mocker.patch(
+            "codereviewbuddy.tools.wait.list_review_comments",
+            new_callable=AsyncMock,
+            return_value=pending_summary,
+        )
+        mocker.patch("codereviewbuddy.tools.wait.asyncio.sleep", new_callable=AsyncMock)
+
+        result = await wait_for_reviews(42, repo="owner/repo", timeout=60, poll_interval=30)
+        # Polls: t=0 (poll), sleep 30, t=30 (poll), sleep 30, t=60 (poll) → 3 polls
+        # After 3rd poll, elapsed=60, next sleep would exceed timeout → return
+        assert result.reviews_in_progress is True
+        assert mock_list.call_count == 3
+
+    async def test_no_reviewer_statuses_returns_immediately(self, mocker: MockerFixture):
+        """No known reviewers on the PR → reviews_in_progress=False → return immediately."""
+        summary = ReviewSummary(threads=[], reviewer_statuses=[], reviews_in_progress=False)
+
+        from unittest.mock import AsyncMock
+
+        mocker.patch(
+            "codereviewbuddy.tools.wait.list_review_comments",
+            new_callable=AsyncMock,
+            return_value=summary,
+        )
+
+        result = await wait_for_reviews(42, repo="owner/repo")
+        assert result.reviews_in_progress is False
+
+    async def test_rejects_zero_poll_interval(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="poll_interval must be positive"):
+            await wait_for_reviews(42, repo="owner/repo", poll_interval=0)
+
+    async def test_rejects_negative_poll_interval(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="poll_interval must be positive"):
+            await wait_for_reviews(42, repo="owner/repo", poll_interval=-5)
+
+    async def test_rejects_negative_timeout(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="timeout must be non-negative"):
+            await wait_for_reviews(42, repo="owner/repo", timeout=-1)


### PR DESCRIPTION
## Summary

Closes #46, closes #4.

Detects whether AI reviewers (Devin, Unblocked) have finished reviewing the latest push on a PR, preventing premature merges that miss in-progress reviews.

## What changed

### New: Review status detection (enriches `list_review_comments`)

`list_review_comments` now returns a `ReviewSummary` instead of a plain list of threads. The summary includes:

- **`reviewer_statuses`** — per-reviewer status (`completed` or `pending`) based on timestamp heuristic
- **`reviews_in_progress`** — boolean flag: true if any reviewer hasn't reviewed since the latest push

**Detection logic** (timestamp heuristic):
1. Fetch the latest commit timestamp from the PR commits API
2. For each known AI reviewer that has posted on this PR, find their most recent comment/review timestamp
3. If `last_review_at >= last_push_at` → completed; otherwise → pending

This is **data-driven**: only reports on reviewers actually seen on the PR. No assumptions about which reviewers are installed.

### New: `wait_for_reviews` tool

Polls `list_review_comments` at a configurable interval until all reviewers are done or timeout is reached. Useful for blocking before merge.

### Updated: `list_stack_review_comments`

Return type updated to `dict[int, ReviewSummary]` for consistency.

## Key design decisions

- **No Check Runs API** — verified on real PRs that Devin/CodeRabbit/Unblocked don't create check runs or commit statuses
- **No-comments edge case** — if a reviewer has never commented on a PR, we don't report on them (can't distinguish "not installed" from "clean review")
- **CodeRabbit not assumed** — adapter stays but detection won't report it unless it's actually posting

## Files changed

| File | Change |
|------|--------|
| `src/codereviewbuddy/models.py` | New `ReviewerStatus` and `ReviewSummary` models |
| `src/codereviewbuddy/tools/comments.py` | Added `_get_latest_push_time`, `_build_reviewer_statuses`; changed return types |
| `src/codereviewbuddy/tools/wait.py` | New `wait_for_reviews` tool |
| `src/codereviewbuddy/server.py` | Registered `wait_for_reviews`, updated instructions and types |
| `tests/test_comments.py` | Extended for `ReviewSummary`, added reviewer status tests |
| `tests/test_wait.py` | New: polling, timeout, immediate-return tests |
| `tests/test_mcp_integration.py` | Updated expected tool count |

## Testing

- 128 tests pass (`poe test`)
- Lint clean (`poe lint`)
- Coverage: 96.83%
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
