### PR TITLE
fix: defensive error handling to prevent MCP connection corruption (#56)

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -55,6 +55,7 @@ class ReviewSummary(BaseModel):
     reviews_in_progress: bool = Field(
         default=False, description="True if at least one reviewer has a pending review (pushed after last review)"
     )
+    error: str | None = Field(default=None, description="Error message if the request failed")
 
 
 class StackPR(BaseModel):
@@ -82,6 +83,7 @@ class ResolveStaleResult(BaseModel):
     resolved_count: int = Field(description="Number of threads resolved")
     resolved_thread_ids: list[str] = Field(default_factory=list, description="Thread IDs that were resolved")
     skipped_count: int = Field(default=0, description="Threads skipped because the reviewer auto-resolves (e.g. Devin, CodeRabbit)")
+    error: str | None = Field(default=None, description="Error message if the request failed")
 
 
 class RereviewResult(BaseModel):
@@ -89,6 +91,7 @@ class RereviewResult(BaseModel):
 
     triggered: list[str] = Field(default_factory=list, description="Reviewers that were manually triggered")
     auto_triggers: list[str] = Field(default_factory=list, description="Reviewers that auto-trigger on push (no action needed)")
+    error: str | None = Field(default=None, description="Error message if the request failed")
 
 
 class UpdateCheckResult(BaseModel):
@@ -98,11 +101,13 @@ class UpdateCheckResult(BaseModel):
     latest_version: str = Field(description="Latest version on PyPI, or 'unknown' if check failed")
     update_available: bool = Field(description="Whether a newer version is available")
     upgrade_command: str = Field(default="uvx --upgrade codereviewbuddy", description="Command to upgrade")
+    error: str | None = Field(default=None, description="Error message if the request failed")
 
 
 class CreateIssueResult(BaseModel):
     """Result of creating a GitHub issue from a review comment."""
 
-    issue_number: int = Field(description="Created issue number")
-    issue_url: str = Field(description="URL of the created issue")
-    title: str = Field(description="Issue title")
+    issue_number: int = Field(default=0, description="Created issue number")
+    issue_url: str = Field(default="", description="URL of the created issue")
+    title: str = Field(default="", description="Issue title")
+    error: str | None = Field(default=None, description="Error message if the request failed")


### PR DESCRIPTION
## Problem

When a codereviewbuddy MCP tool encounters an error (e.g. invalid thread ID, GitHub API failure), the exception propagates through FastMCP's ErrorHandlingMiddleware and gets converted to an MCP error response. Windsurf's MCP client does not properly recover from these error responses — the connection state becomes **permanently corrupted**, requiring a full window reload to restore.

This was observed 3 times during a single review session on PR #53:
1. `resolve_comment` with an invalidated thread ID (Devin auto-dismissed)
2. `reply_to_comment` with a stale thread ID
3. `wait_for_reviews` timing out while polling

## Solution

**Belt and suspenders**: wrap every tool function in `server.py` with `try/except Exception` to catch errors at the tool boundary and return normal responses with an embedded `error` field — instead of letting exceptions propagate to the middleware.

### Changes

**`src/codereviewbuddy/models.py`**
- Added `error: str | None = None` field to `ReviewSummary`, `ResolveStaleResult`, `RereviewResult`, `CreateIssueResult`
- Made `CreateIssueResult` fields optional (defaults for error case)

**`src/codereviewbuddy/server.py`**
- All 10 tool functions now catch `Exception` and return a valid response with the error message
- `ErrorHandlingMiddleware` remains as a last-resort safety net
- Errors are logged via `logger.exception()` for server-side visibility

**`tests/test_mcp_integration.py`**
- Updated `test_failure_propagates` → `test_failure_returns_error_string`: verifies error is returned as normal response, not raised
- Updated `test_unknown_reviewer_error` → `test_unknown_reviewer_returns_error`: same pattern
- Removed unused `ToolError` import

## Design rationale

We **keep** the ErrorHandlingMiddleware — it's still useful as a fallback for truly unexpected errors. But in normal operation, no exception should ever reach it. This is a pragmatic workaround for a Windsurf client bug where MCP error responses corrupt the connection.

Fixes #56
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
