### PR TITLE
fix: resolve_stale_comments now resolves Devin info threads (#55)

### DIFF
--- a/src/codereviewbuddy/reviewers/base.py
+++ b/src/codereviewbuddy/reviewers/base.py
@@ -28,6 +28,14 @@ class ReviewerAdapter(ABC):
     def auto_resolves_comments(self) -> bool:
         """Whether this reviewer auto-resolves addressed comments on new pushes."""
 
+    def auto_resolves_thread(self, comment_body: str) -> bool:  # noqa: ARG002
+        """Whether this reviewer will auto-resolve a specific thread.
+
+        Override to make per-thread decisions based on comment content.
+        Defaults to ``auto_resolves_comments`` (all-or-nothing).
+        """
+        return self.auto_resolves_comments
+
     @abstractmethod
     def identify(self, author: str) -> bool:
         """Return True if the given GitHub username belongs to this reviewer."""

--- a/src/codereviewbuddy/reviewers/devin.py
+++ b/src/codereviewbuddy/reviewers/devin.py
@@ -25,6 +25,10 @@ class DevinAdapter(ReviewerAdapter):
     def auto_resolves_comments(self) -> bool:
         return True
 
+    def auto_resolves_thread(self, comment_body: str) -> bool:
+        """Devin only auto-resolves bug/investigation threads, not info threads."""
+        return "📝" not in comment_body
+
     def identify(self, author: str) -> bool:
         normalized = author.lower().strip()
         return "devin" in normalized

--- a/tests/test_reviewers.py
+++ b/tests/test_reviewers.py
@@ -67,6 +67,18 @@ class TestDevinAdapter:
         assert adapter.needs_manual_rereview is False
         assert adapter.auto_resolves_comments is True
 
+    def test_auto_resolves_bug_thread(self):
+        adapter = DevinAdapter()
+        assert adapter.auto_resolves_thread("🔴 **Bug: null pointer**") is True
+
+    def test_auto_resolves_flag_thread(self):
+        adapter = DevinAdapter()
+        assert adapter.auto_resolves_thread("🚩 **check_for_updates not wrapped**") is True
+
+    def test_does_not_auto_resolve_info_thread(self):
+        adapter = DevinAdapter()
+        assert adapter.auto_resolves_thread("📝 **Info: This is informational**") is False
+
     def test_rereview_trigger_empty(self):
         adapter = DevinAdapter()
         assert adapter.rereview_trigger(42, "owner", "repo") == []


### PR DESCRIPTION
## Problem

`resolve_stale_comments` skips **all** threads from reviewers where `auto_resolves_comments = True` (Devin, CodeRabbit). But Devin only auto-resolves 🔴 bug and 🚩 investigation threads — it does **not** auto-resolve 📝 info comments.

This leaves orphaned stale threads that neither `resolve_stale_comments` nor Devin will ever resolve. Observed on PR #53: 9 stale Devin threads remained, 7 of which were info threads Devin would never touch.

## Solution

Make the skip logic **per-thread** instead of per-reviewer. Added `auto_resolves_thread(comment_body)` to the adapter system so each reviewer can make granular decisions based on comment content.

### Changes

**`src/codereviewbuddy/reviewers/base.py`**
- Added `auto_resolves_thread(comment_body) -> bool` with default falling back to `auto_resolves_comments`

**`src/codereviewbuddy/reviewers/devin.py`**
- Overrides `auto_resolves_thread`: returns `False` for 📝 info threads (we resolve them), `True` for everything else (Devin handles those)

**`src/codereviewbuddy/tools/comments.py`**
- `_reviewer_auto_resolves` now accepts `comment_body` and delegates to `adapter.auto_resolves_thread(body)`
- `resolve_stale_comments` passes the first comment's body for per-thread decisions

**Tests**
- `test_resolves_devin_info_threads`: verifies 📝 info threads are resolved (not skipped)
- `test_skips_auto_resolving_reviewers`: existing test still validates bug threads are skipped
- 3 new adapter-level tests for `auto_resolves_thread` (bug ✅, flag ✅, info ❌)

Fixes #55
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
