### PR TITLE
feat: add raw I/O tap for stdio transport diagnostics (#65)

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -340,6 +340,9 @@ async def check_for_updates() -> UpdateCheckResult:
 
 def main() -> None:
     """Run the codereviewbuddy MCP server."""
+    from codereviewbuddy.io_tap import install_io_tap
+
+    install_io_tap()
     mcp.run()
 
 


### PR DESCRIPTION
New io_tap module wraps sys.stdin/sys.stdout to log every JSON-RPC line
at the byte level before the MCP library touches them. Provides a
ground-truth audit trail for diagnosing transport hangs.

- Transparent proxy delegates all attribute access to wrapped streams
- Logs to ~/.codereviewbuddy/io_tap.jsonl
- Opt-in via CODEREVIEWBUDDY_IO_TAP=1 environment variable
- Installed in main() before FastMCP starts stdio transport

## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
