### PR TITLE
feat: per-reviewer configuration system (#64)

### DIFF
--- a/.codereviewbuddy.toml
+++ b/.codereviewbuddy.toml
@@ -1,0 +1,24 @@
+# .codereviewbuddy.toml — Per-reviewer configuration for codereviewbuddy
+# All settings are optional. Omitted values use sensible defaults.
+# Place this file in your project root (next to .git/).
+#
+# Severity levels used by resolve_levels:
+#   bug      — 🔴 critical issues, must fix before merge
+#   flagged  — 🚩 likely needs a code change
+#   warning  — 🟡 worth addressing but not blocking
+#   info     — 📝 informational, no action required
+
+[reviewers.devin]
+enabled = true                  # Set to false to ignore Devin comments entirely
+auto_resolve_stale = false      # Devin auto-resolves its own bug threads; we skip them
+resolve_levels = ["info"]       # Only allow resolving info-level threads from Devin
+
+[reviewers.unblocked]
+# enabled = true
+# auto_resolve_stale = true       # We batch-resolve Unblocked's stale threads
+# resolve_levels = ["info", "warning", "flagged", "bug"]  # All levels allowed
+
+[reviewers.coderabbit]
+# enabled = true
+# auto_resolve_stale = false      # CodeRabbit handles its own resolution
+# resolve_levels = []             # Don't resolve any CodeRabbit threads

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,8 +1,8 @@
 # Lychee link checker configuration
 # https://github.com/lycheeverse/lychee
 
-# Don't check the config file itself or test fixtures
-exclude_path = [".lychee.toml", "tests/"]
+# Don't check the config file itself, test fixtures, or Jinja2 template overrides
+exclude_path = [".lychee.toml", "tests/", "docs/.overrides/"]
 
 # Exclude placeholder and example URLs
 exclude = [

--- a/prek.toml
+++ b/prek.toml
@@ -1,5 +1,6 @@
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.2"
+default_install_hook_types = ["commit-msg", "post-checkout", "post-commit", "post-merge", "post-rewrite", "pre-commit", "pre-merge-commit", "pre-push", "pre-rebase", "prepare-commit-msg"]
 
 [[repos]]
 repo = "builtin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ source = ["src/", "tests/"]
 
 [tool.coverage.report]
 precision = 2
+fail_under = 90
 omit = ["src/*/__init__.py", "tests/__init__.py"]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 

--- a/src/codereviewbuddy/config.py
+++ b/src/codereviewbuddy/config.py
@@ -1,0 +1,211 @@
+"""Per-reviewer configuration system.
+
+Loads ``.codereviewbuddy.toml`` from the project root (walking up to ``.git``),
+validates with Pydantic, and provides sensible defaults so zero-config still works.
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+CONFIG_FILENAME = ".codereviewbuddy.toml"
+
+
+class Severity(StrEnum):
+    """Comment severity levels, ordered from least to most critical."""
+
+    INFO = "info"
+    WARNING = "warning"
+    FLAGGED = "flagged"
+    BUG = "bug"
+
+
+# -- Per-reviewer defaults (match current hardcoded adapter behavior) ----------
+
+_REVIEWER_DEFAULTS: dict[str, dict[str, Any]] = {
+    "devin": {
+        "enabled": True,
+        "auto_resolve_stale": False,  # Devin auto-resolves its own bug threads
+        "resolve_levels": [Severity.INFO],  # Only allow resolving info-level
+    },
+    "unblocked": {
+        "enabled": True,
+        "auto_resolve_stale": True,  # We batch-resolve Unblocked's stale threads
+        "resolve_levels": [Severity.INFO, Severity.WARNING, Severity.FLAGGED, Severity.BUG],
+    },
+    "coderabbit": {
+        "enabled": True,
+        "auto_resolve_stale": False,  # CodeRabbit handles its own resolution
+        "resolve_levels": [],  # Don't resolve any CodeRabbit threads
+    },
+}
+
+
+class ReviewerConfig(BaseModel):
+    """Configuration for a single reviewer."""
+
+    enabled: bool = Field(default=True, description="Whether this reviewer integration is active")
+    auto_resolve_stale: bool = Field(
+        default=True,
+        description="Whether resolve_stale_comments touches this reviewer's threads",
+    )
+    resolve_levels: list[Severity] = Field(
+        default_factory=lambda: list(Severity),
+        description="Severity levels that are allowed to be resolved",
+    )
+
+
+class Config(BaseModel):
+    """Top-level codereviewbuddy configuration."""
+
+    reviewers: dict[str, ReviewerConfig] = Field(
+        default_factory=dict,
+        description="Per-reviewer configuration sections",
+    )
+
+    @model_validator(mode="after")
+    def _apply_reviewer_defaults(self) -> Config:
+        """Fill in missing reviewers with their hardcoded defaults.
+
+        For partially-specified reviewers, merge unset fields from
+        ``_REVIEWER_DEFAULTS`` so that e.g. ``[reviewers.devin]\\nenabled = false``
+        still gets ``auto_resolve_stale=False`` (Devin's safe default) rather
+        than the generic ``ReviewerConfig`` field default (``True``).
+        """
+        for name, defaults in _REVIEWER_DEFAULTS.items():
+            if name not in self.reviewers:
+                self.reviewers[name] = ReviewerConfig(**defaults)
+            else:
+                rc = self.reviewers[name]
+                for field_name, default_value in defaults.items():
+                    if field_name not in rc.model_fields_set:
+                        setattr(rc, field_name, default_value)
+        return self
+
+    def get_reviewer(self, name: str) -> ReviewerConfig:
+        """Get config for a reviewer, falling back to permissive defaults for unknown reviewers."""
+        if name in self.reviewers:
+            return self.reviewers[name]
+        # Unknown reviewer: enabled, all levels resolvable, auto-resolve on
+        return ReviewerConfig()
+
+    def can_resolve(self, reviewer_name: str, severity: Severity) -> tuple[bool, str]:
+        """Check if resolving a thread is allowed by config.
+
+        Args:
+            reviewer_name: Name of the reviewer that posted the thread.
+            severity: Severity of the thread (from the adapter's ``classify_severity``).
+
+        Returns:
+            (allowed, reason) — if not allowed, reason explains why.
+        """
+        rc = self.get_reviewer(reviewer_name)
+        if not rc.enabled:
+            return False, f"Reviewer '{reviewer_name}' is disabled in config"
+        if severity not in rc.resolve_levels:
+            return False, (
+                f"Config blocks resolving {severity}-level threads from {reviewer_name}. "
+                f"Allowed levels: {[s.value for s in rc.resolve_levels]}"
+            )
+        return True, ""
+
+
+def _find_config_file(start: Path) -> Path | None:
+    """Walk up from *start* looking for ``.codereviewbuddy.toml``, stopping at ``.git`` root."""
+    current = start.resolve()
+    while True:
+        candidate = current / CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+        # Stop at filesystem root
+        if current.parent == current:
+            return None
+        # Stop if we just checked a directory that contains .git
+        if (current / ".git").exists():
+            return None
+        current = current.parent
+
+
+def load_config(cwd: str | Path | None = None) -> Config:
+    """Load configuration from ``.codereviewbuddy.toml``.
+
+    Walks up from *cwd* (defaulting to the current directory) looking for the
+    config file.  If not found, returns a ``Config`` with all defaults.
+
+    Raises ``ValueError`` on invalid TOML or validation errors so the server
+    can refuse to start with a broken config.
+    """
+    start = Path(cwd) if cwd else Path.cwd()
+    config_path = _find_config_file(start)
+
+    if config_path is None:
+        logger.info("No %s found, using defaults", CONFIG_FILENAME)
+        return Config()
+
+    logger.info("Loading config from %s", config_path)
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+        data = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"Invalid TOML in {config_path}: {exc}"
+        raise ValueError(msg) from exc
+
+    try:
+        return Config.model_validate(data)
+    except Exception as exc:
+        msg = f"Invalid config in {config_path}: {exc}"
+        raise ValueError(msg) from exc
+
+
+# -- Global config instance (set during server lifespan) -----------------------
+
+_config: Config = Config()
+
+
+def get_config() -> Config:
+    """Return the active configuration."""
+    return _config
+
+
+def set_config(config: Config) -> None:
+    """Set the active configuration (called during server startup)."""
+    global _config
+    _config = config
+
+
+# -- Self-documenting template for ``codereviewbuddy init`` --------------------
+
+DEFAULT_CONFIG_TEMPLATE = """\
+# .codereviewbuddy.toml — Per-reviewer configuration for codereviewbuddy
+# All settings are optional. Omitted values use sensible defaults.
+# Place this file in your project root (next to .git/).
+#
+# Severity levels used by resolve_levels:
+#   bug      — 🔴 critical issues, must fix before merge
+#   flagged  — 🚩 likely needs a code change
+#   warning  — 🟡 worth addressing but not blocking
+#   info     — 📝 informational, no action required
+
+[reviewers.devin]
+# enabled = true                  # Set to false to ignore Devin comments entirely
+# auto_resolve_stale = false      # Devin auto-resolves its own bug threads; we skip them
+# resolve_levels = ["info"]       # Only allow resolving info-level threads from Devin
+
+[reviewers.unblocked]
+# enabled = true
+# auto_resolve_stale = true       # We batch-resolve Unblocked's stale threads
+# resolve_levels = ["info", "warning", "flagged", "bug"]  # All levels allowed
+
+[reviewers.coderabbit]
+# enabled = true
+# auto_resolve_stale = false      # CodeRabbit handles its own resolution
+# resolve_levels = []             # Don't resolve any CodeRabbit threads
+"""

--- a/src/codereviewbuddy/io_tap.py
+++ b/src/codereviewbuddy/io_tap.py
@@ -172,8 +172,8 @@ def install_io_tap() -> bool:
     original_stdin = sys.stdin
     original_stdout = sys.stdout
     try:
-        sys.stdin = _TappedStream(sys.stdin, "stdin", LOG_FILE)  # type: ignore[assignment]
-        sys.stdout = _TappedStream(sys.stdout, "stdout", LOG_FILE)  # type: ignore[assignment]
+        sys.stdin = _TappedStream(sys.stdin, "stdin", LOG_FILE)
+        sys.stdout = _TappedStream(sys.stdout, "stdout", LOG_FILE)
     except Exception:
         sys.stdin = original_stdin
         sys.stdout = original_stdout

--- a/src/codereviewbuddy/middleware.py
+++ b/src/codereviewbuddy/middleware.py
@@ -72,7 +72,7 @@ class WriteOperationMiddleware(Middleware):
     def _append_log(self, entry: dict[str, Any]) -> None:
         """Append a JSON log entry to the tool_calls.jsonl file."""
         try:
-            with self._log_file.open("a") as f:
+            with self._log_file.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(entry, default=str) + "\n")
         except OSError:
             logger.warning("Could not write to log file: %s", self._log_file)
@@ -82,9 +82,9 @@ class WriteOperationMiddleware(Middleware):
         try:
             if not self._log_file.exists():
                 return
-            lines = self._log_file.read_text().splitlines()
+            lines = self._log_file.read_text(encoding="utf-8").splitlines()
             if len(lines) > MAX_LOG_LINES:
-                self._log_file.write_text("\n".join(lines[-MAX_LOG_LINES:]) + "\n")
+                self._log_file.write_text("\n".join(lines[-MAX_LOG_LINES:]) + "\n", encoding="utf-8")
         except OSError:
             pass
 

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -83,6 +83,7 @@ class ResolveStaleResult(BaseModel):
     resolved_count: int = Field(description="Number of threads resolved")
     resolved_thread_ids: list[str] = Field(default_factory=list, description="Thread IDs that were resolved")
     skipped_count: int = Field(default=0, description="Threads skipped because the reviewer auto-resolves (e.g. Devin, CodeRabbit)")
+    blocked_count: int = Field(default=0, description="Threads blocked by resolve_levels config (severity too high)")
     error: str | None = Field(default=None, description="Error message if the request failed")
 
 

--- a/src/codereviewbuddy/reviewers/__init__.py
+++ b/src/codereviewbuddy/reviewers/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from codereviewbuddy.reviewers.base import ReviewerAdapter
 from codereviewbuddy.reviewers.coderabbit import CodeRabbitAdapter
 from codereviewbuddy.reviewers.devin import DevinAdapter
-from codereviewbuddy.reviewers.registry import REVIEWERS, get_reviewer, identify_reviewer
+from codereviewbuddy.reviewers.registry import REVIEWERS, apply_config, get_reviewer, identify_reviewer
 from codereviewbuddy.reviewers.unblocked import UnblockedAdapter
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "DevinAdapter",
     "ReviewerAdapter",
     "UnblockedAdapter",
+    "apply_config",
     "get_reviewer",
     "identify_reviewer",
 ]

--- a/src/codereviewbuddy/reviewers/base.py
+++ b/src/codereviewbuddy/reviewers/base.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from codereviewbuddy.config import ReviewerConfig, Severity
 
 
 class ReviewerAdapter(ABC):
@@ -11,7 +15,24 @@ class ReviewerAdapter(ABC):
     Each adapter encodes the behavior quirks of a specific AI reviewer:
     whether it needs manual re-review triggers, whether it auto-resolves
     comments, and how to identify its comments by author username.
+
+    Call :meth:`configure` to apply per-reviewer config overrides from
+    ``.codereviewbuddy.toml``.  Without configuration, adapters use their
+    hardcoded defaults.
     """
+
+    _config: ReviewerConfig | None = None
+
+    def configure(self, config: ReviewerConfig) -> None:
+        """Apply per-reviewer configuration overrides."""
+        self._config = config
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this reviewer integration is active."""
+        if self._config is not None:
+            return self._config.enabled
+        return True
 
     @property
     @abstractmethod
@@ -27,6 +48,17 @@ class ReviewerAdapter(ABC):
     @abstractmethod
     def auto_resolves_comments(self) -> bool:
         """Whether this reviewer auto-resolves addressed comments on new pushes."""
+
+    def classify_severity(self, comment_body: str) -> Severity:  # noqa: ARG002
+        """Classify the severity of a comment based on reviewer-specific markers.
+
+        Each reviewer uses different formats (emojis, labels, etc.) to indicate
+        severity.  Override in subclasses that have known formats.  The default
+        returns ``info`` — the safest assumption for unknown formats.
+        """
+        from codereviewbuddy.config import Severity
+
+        return Severity.INFO
 
     def auto_resolves_thread(self, comment_body: str) -> bool:  # noqa: ARG002
         """Whether this reviewer will auto-resolve a specific thread.

--- a/src/codereviewbuddy/reviewers/devin.py
+++ b/src/codereviewbuddy/reviewers/devin.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, ClassVar
+
 from codereviewbuddy.reviewers.base import ReviewerAdapter
+
+if TYPE_CHECKING:
+    from codereviewbuddy.config import Severity
 
 
 class DevinAdapter(ReviewerAdapter):
@@ -24,6 +29,24 @@ class DevinAdapter(ReviewerAdapter):
     @property
     def auto_resolves_comments(self) -> bool:
         return True
+
+    # Devin's known emoji markers (verified from PR review comments).
+    # Ordered most-critical-first so the first match wins.
+    _EMOJI_SEVERITY: ClassVar[list[tuple[str, str]]] = [
+        ("🔴", "bug"),
+        ("🚩", "flagged"),
+        ("🟡", "warning"),
+        ("📝", "info"),
+    ]
+
+    def classify_severity(self, comment_body: str) -> Severity:
+        """Classify using Devin's emoji markers: 🔴 bug, 🚩 flagged, 🟡 warning, 📝 info."""
+        from codereviewbuddy.config import Severity
+
+        for emoji, level in self._EMOJI_SEVERITY:
+            if emoji in comment_body:
+                return Severity(level)
+        return Severity.INFO
 
     def auto_resolves_thread(self, comment_body: str) -> bool:
         """Devin only auto-resolves bug/investigation threads, not info threads."""

--- a/src/codereviewbuddy/reviewers/registry.py
+++ b/src/codereviewbuddy/reviewers/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from codereviewbuddy.config import Config
     from codereviewbuddy.reviewers.base import ReviewerAdapter
 
 
@@ -22,6 +23,13 @@ def _build_registry() -> list[ReviewerAdapter]:
 
 
 REVIEWERS: list[ReviewerAdapter] = _build_registry()
+
+
+def apply_config(config: Config) -> None:
+    """Apply per-reviewer configuration to all registered adapters."""
+    for adapter in REVIEWERS:
+        rc = config.get_reviewer(adapter.name)
+        adapter.configure(rc)
 
 
 def identify_reviewer(author: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,232 @@
+"""Tests for the per-reviewer configuration system."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from codereviewbuddy.config import (
+    Config,
+    ReviewerConfig,
+    Severity,
+    load_config,
+)
+
+
+class TestReviewerConfig:
+    def test_defaults(self):
+        rc = ReviewerConfig()
+        assert rc.enabled is True
+        assert rc.auto_resolve_stale is True
+        assert set(rc.resolve_levels) == set(Severity)
+
+    def test_custom_resolve_levels(self):
+        rc = ReviewerConfig(resolve_levels=[Severity.INFO, Severity.WARNING])
+        assert rc.resolve_levels == [Severity.INFO, Severity.WARNING]
+
+    def test_empty_resolve_levels(self):
+        rc = ReviewerConfig(resolve_levels=[])
+        assert rc.resolve_levels == []
+
+
+class TestConfig:
+    def test_defaults_fill_known_reviewers(self):
+        config = Config()
+        assert "devin" in config.reviewers
+        assert "unblocked" in config.reviewers
+        assert "coderabbit" in config.reviewers
+
+    def test_devin_defaults(self):
+        config = Config()
+        devin = config.reviewers["devin"]
+        assert devin.enabled is True
+        assert devin.auto_resolve_stale is False
+        assert devin.resolve_levels == [Severity.INFO]
+
+    def test_unblocked_defaults(self):
+        config = Config()
+        unblocked = config.reviewers["unblocked"]
+        assert unblocked.enabled is True
+        assert unblocked.auto_resolve_stale is True
+        assert set(unblocked.resolve_levels) == set(Severity)
+
+    def test_coderabbit_defaults(self):
+        config = Config()
+        coderabbit = config.reviewers["coderabbit"]
+        assert coderabbit.enabled is True
+        assert coderabbit.auto_resolve_stale is False
+        assert coderabbit.resolve_levels == []
+
+    def test_partial_override_preserves_other_defaults(self):
+        config = Config(reviewers={"devin": ReviewerConfig(resolve_levels=[Severity.INFO, Severity.WARNING])})
+        # Devin override applied
+        assert config.reviewers["devin"].resolve_levels == [Severity.INFO, Severity.WARNING]
+        assert config.reviewers["devin"].enabled is True  # field default
+        # Unset fields get reviewer-specific defaults, NOT generic ReviewerConfig defaults
+        assert config.reviewers["devin"].auto_resolve_stale is False  # Devin's safe default
+        # Other reviewers still get their defaults
+        assert config.reviewers["unblocked"].auto_resolve_stale is True
+        assert config.reviewers["coderabbit"].resolve_levels == []
+
+    def test_partial_override_devin_disabled_preserves_safe_defaults(self):
+        """Setting only enabled=False should keep Devin's restrictive resolve_levels and auto_resolve_stale."""
+        config = Config(reviewers={"devin": ReviewerConfig(enabled=False)})
+        assert config.reviewers["devin"].enabled is False
+        assert config.reviewers["devin"].auto_resolve_stale is False  # Devin-specific, not generic True
+        assert config.reviewers["devin"].resolve_levels == [Severity.INFO]  # Devin-specific, not all severities
+
+    def test_empty_section_preserves_reviewer_defaults(self):
+        """Empty TOML section (no fields set) should behave like zero-config for that reviewer."""
+        config = Config(reviewers={"devin": ReviewerConfig()})
+        assert config.reviewers["devin"].auto_resolve_stale is False  # Devin-specific default
+        assert config.reviewers["devin"].resolve_levels == [Severity.INFO]  # Devin-specific default
+
+    def test_unknown_reviewer_gets_permissive_defaults(self):
+        config = Config()
+        rc = config.get_reviewer("some-new-reviewer")
+        assert rc.enabled is True
+        assert rc.auto_resolve_stale is True
+        assert set(rc.resolve_levels) == set(Severity)
+
+
+class TestCanResolve:
+    def test_allowed_severity(self):
+        config = Config()
+        allowed, reason = config.can_resolve("unblocked", Severity.INFO)
+        assert allowed is True
+        assert reason == ""
+
+    def test_blocked_severity(self):
+        config = Config()
+        allowed, reason = config.can_resolve("devin", Severity.BUG)
+        assert allowed is False
+        assert "bug" in reason.lower()
+        assert "devin" in reason.lower()
+
+    def test_blocked_disabled_reviewer(self):
+        config = Config(reviewers={"devin": ReviewerConfig(enabled=False)})
+        allowed, reason = config.can_resolve("devin", Severity.INFO)
+        assert allowed is False
+        assert "disabled" in reason.lower()
+
+    def test_coderabbit_blocks_all(self):
+        config = Config()
+        allowed, reason = config.can_resolve("coderabbit", Severity.INFO)
+        assert allowed is False
+        assert "info" in reason.lower()
+
+    def test_devin_allows_info_only(self):
+        config = Config()
+        for severity, should_allow in [
+            (Severity.INFO, True),
+            (Severity.WARNING, False),
+            (Severity.FLAGGED, False),
+            (Severity.BUG, False),
+        ]:
+            allowed, _ = config.can_resolve("devin", severity)
+            assert allowed is should_allow, f"Expected {should_allow} for severity={severity!r}"
+
+    def test_unblocked_allows_all(self):
+        config = Config()
+        for severity in Severity:
+            allowed, _ = config.can_resolve("unblocked", severity)
+            assert allowed is True, f"Expected True for severity={severity!r}"
+
+
+class TestLoadConfig:
+    def test_missing_file_returns_defaults(self, tmp_path: Path):
+        config = load_config(cwd=tmp_path)
+        assert "devin" in config.reviewers
+        assert config.reviewers["devin"].resolve_levels == [Severity.INFO]
+
+    def test_load_valid_toml(self, tmp_path: Path):
+        # Create a git root so the walk-up stops
+        (tmp_path / ".git").mkdir()
+        config_file = tmp_path / ".codereviewbuddy.toml"
+        config_file.write_text(
+            """\
+[reviewers.devin]
+resolve_levels = ["info", "warning"]
+
+[reviewers.unblocked]
+auto_resolve_stale = false
+""",
+            encoding="utf-8",
+        )
+        config = load_config(cwd=tmp_path)
+        assert config.reviewers["devin"].resolve_levels == [Severity.INFO, Severity.WARNING]
+        assert config.reviewers["unblocked"].auto_resolve_stale is False
+        # coderabbit still gets defaults
+        assert config.reviewers["coderabbit"].auto_resolve_stale is False
+
+    def test_load_walks_up_to_git_root(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".codereviewbuddy.toml").write_text(
+            "[reviewers.devin]\nenabled = false\n",
+            encoding="utf-8",
+        )
+        subdir = tmp_path / "src" / "deep"
+        subdir.mkdir(parents=True)
+        config = load_config(cwd=subdir)
+        assert config.reviewers["devin"].enabled is False
+
+    def test_stops_at_git_root(self, tmp_path: Path):
+        # Config above git root should not be found
+        (tmp_path / ".codereviewbuddy.toml").write_text(
+            "[reviewers.devin]\nenabled = false\n",
+            encoding="utf-8",
+        )
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        config = load_config(cwd=project)
+        # Should NOT find the config above .git — devin stays enabled (default)
+        assert config.reviewers["devin"].enabled is True
+
+    def test_invalid_toml_raises(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".codereviewbuddy.toml").write_text("{{invalid toml", encoding="utf-8")
+        with pytest.raises(ValueError, match="Invalid TOML"):
+            load_config(cwd=tmp_path)
+
+    def test_invalid_config_values_raises(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".codereviewbuddy.toml").write_text(
+            '[reviewers.devin]\nresolve_levels = ["not_a_severity"]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="Invalid config"):
+            load_config(cwd=tmp_path)
+
+    def test_empty_config_file_returns_defaults(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".codereviewbuddy.toml").write_text("", encoding="utf-8")
+        config = load_config(cwd=tmp_path)
+        assert "devin" in config.reviewers
+
+    def test_init_template_empty_sections_match_zero_config(self, tmp_path: Path):
+        """Init template has [reviewers.devin] etc. with all values commented out.
+
+        TOML parses these as empty dicts. Verify the result matches zero-config defaults.
+        """
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".codereviewbuddy.toml").write_text(
+            """\
+[reviewers.devin]
+
+[reviewers.unblocked]
+
+[reviewers.coderabbit]
+""",
+            encoding="utf-8",
+        )
+        config = load_config(cwd=tmp_path)
+        zero = Config()
+        for name in ("devin", "unblocked", "coderabbit"):
+            assert config.reviewers[name].enabled == zero.reviewers[name].enabled, name
+            assert config.reviewers[name].auto_resolve_stale == zero.reviewers[name].auto_resolve_stale, name
+            assert config.reviewers[name].resolve_levels == zero.reviewers[name].resolve_levels, name

--- a/tests/test_mock_write_server.py
+++ b/tests/test_mock_write_server.py
@@ -1,0 +1,61 @@
+"""Tests for the mock write server helper used by stdio rapid-write tests.
+
+Importing and exercising the tool functions directly gives us coverage
+of tests/helpers/mock_write_server.py (which normally runs as a subprocess
+via PythonStdioTransport and is invisible to coverage).
+"""
+
+from __future__ import annotations
+
+import json
+
+from helpers import mock_write_server
+
+
+class TestMockWriteServerTools:
+    async def test_list_review_comments(self):
+        result = await mock_write_server.list_review_comments(42)  # type: ignore[operator]
+        data = json.loads(result)
+        assert "threads" in data
+
+    async def test_list_review_comments_with_params(self):
+        result = await mock_write_server.list_review_comments(42, repo="owner/repo", status="unresolved")  # type: ignore[operator]
+        data = json.loads(result)
+        assert "threads" in data
+
+    async def test_resolve_stale_comments(self):
+        result = await mock_write_server.resolve_stale_comments(42)  # type: ignore[operator]
+        data = json.loads(result)
+        assert data["resolved_count"] == 1
+
+    async def test_resolve_stale_comments_with_repo(self):
+        result = await mock_write_server.resolve_stale_comments(42, repo="owner/repo")  # type: ignore[operator]
+        data = json.loads(result)
+        assert "resolved_thread_ids" in data
+
+    def test_resolve_comment(self):
+        result = mock_write_server.resolve_comment(42, "PRRT_test1")  # type: ignore[operator]
+        assert "PRRT_test1" in result
+
+    def test_reply_to_comment(self):
+        result = mock_write_server.reply_to_comment(42, "PRRT_test1", "Fixed")  # type: ignore[operator]
+        assert "PRRT_test1" in result
+
+    def test_reply_to_comment_with_repo(self):
+        result = mock_write_server.reply_to_comment(42, "PRRT_test1", "Fixed", repo="owner/repo")  # type: ignore[operator]
+        assert "PRRT_test1" in result
+
+    async def test_request_rereview(self):
+        result = await mock_write_server.request_rereview(42)  # type: ignore[operator]
+        data = json.loads(result)
+        assert "triggered" in data
+
+    async def test_request_rereview_with_params(self):
+        result = await mock_write_server.request_rereview(42, reviewer="unblocked", repo="owner/repo")  # type: ignore[operator]
+        data = json.loads(result)
+        assert "auto_triggers" in data
+
+    async def test_check_for_updates(self):
+        result = await mock_write_server.check_for_updates()  # type: ignore[operator]
+        data = json.loads(result)
+        assert data["update_available"] is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,69 @@
+"""Tests for server.py — entrypoint, init command, and prerequisites."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+from codereviewbuddy.gh import GhNotAuthenticatedError, GhNotFoundError
+from codereviewbuddy.server import _init_config, check_prerequisites
+
+
+class TestCheckPrerequisites:
+    def test_success(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.server.gh.check_auth", return_value="testuser")
+        check_prerequisites()  # should not raise
+
+    def test_gh_not_found(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.server.gh.check_auth", side_effect=GhNotFoundError())
+        with pytest.raises(GhNotFoundError):
+            check_prerequisites()
+
+    def test_gh_not_authenticated(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.server.gh.check_auth", side_effect=GhNotAuthenticatedError("not auth"))
+        with pytest.raises(GhNotAuthenticatedError):
+            check_prerequisites()
+
+
+class TestInitConfig:
+    def test_creates_config_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
+        _init_config()
+        from codereviewbuddy.config import CONFIG_FILENAME
+
+        assert (tmp_path / CONFIG_FILENAME).exists()
+
+    def test_fails_if_file_exists(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
+        from codereviewbuddy.config import CONFIG_FILENAME
+
+        (tmp_path / CONFIG_FILENAME).write_text("existing", encoding="utf-8")
+        with pytest.raises(SystemExit):
+            _init_config()
+
+
+class TestMain:
+    def test_init_subcommand(self, mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
+        mocker.patch("sys.argv", ["codereviewbuddy", "init"])
+        from codereviewbuddy.server import main
+
+        main()
+        from codereviewbuddy.config import CONFIG_FILENAME
+
+        assert (tmp_path / CONFIG_FILENAME).exists()
+
+    def test_run_server(self, mocker: MockerFixture):
+        mocker.patch("sys.argv", ["codereviewbuddy"])
+        mock_run = mocker.patch("codereviewbuddy.server.mcp.run")
+        mocker.patch("codereviewbuddy.io_tap.install_io_tap", return_value=False)
+        from codereviewbuddy.server import main
+
+        main()
+        mock_run.assert_called_once()


### PR DESCRIPTION
## Description

Add a `.codereviewbuddy.toml` configuration file that gives teams server-side control over per-reviewer resolve policy. Closes #64.

### What it does

- **Config file** (`.codereviewbuddy.toml`) loaded from project root at startup, validated with Pydantic, zero-config defaults match current behavior
- **`resolve_levels`** — controls which severity levels an agent is allowed to resolve per reviewer. **Hard blocks** resolve attempts that exceed the policy (server-side enforcement, agents cannot override)
- **`auto_resolve_stale`** — controls whether `resolve_stale_comments` touches a reviewer's threads at all
- **`enabled`** — disables a reviewer's threads from appearing in results
- **Severity classification is per-adapter** — only Devin has known emoji markers (🔴 bug, 🚩 flagged, 🟡 warning, 📝 info). Unblocked/CodeRabbit default to `info` until their formats are investigated
- **`codereviewbuddy init`** CLI subcommand generates a self-documenting config template
- **`blocked_count`** field added to `ResolveStaleResult` so agents see how many threads were blocked by config

### Default config behavior (zero-config)

| Reviewer | `auto_resolve_stale` | `resolve_levels` |
|----------|---------------------|-----------------|
| Devin | `false` (handles own) | `["info"]` only |
| Unblocked | `true` (we handle) | all levels |
| CodeRabbit | `false` (handles own) | `[]` (none) |

### Files changed

- **New**: `src/codereviewbuddy/config.py`, `tests/test_config.py`
- **Modified**: `reviewers/base.py` (added `classify_severity`, `configure`, `enabled`), `reviewers/devin.py` (emoji classifier), `reviewers/registry.py` (`apply_config`), `tools/comments.py` (resolve enforcement), `models.py` (`blocked_count`), `server.py` (lifespan + CLI init), `README.md` (full Configuration section)

### No new dependencies

- `tomllib` (stdlib Python 3.11+) for TOML parsing
- Pydantic (already available via fastmcp) for validation

## Checklist

- [x] Tests added/updated (22 new config tests, 7 new reviewer severity tests — 192 total passing)
- [x] Documentation updated (README Configuration section, MCP server instructions)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

Closes #64
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
