### PR TITLE
feat: auto-detect PR number from current git branch (#71)

### DIFF
--- a/src/codereviewbuddy/gh.py
+++ b/src/codereviewbuddy/gh.py
@@ -183,6 +183,21 @@ def check_auth(cwd: str | None = None) -> str:
     return "authenticated"
 
 
+def get_current_pr_number(cwd: str | None = None) -> int:
+    """Detect the PR number associated with the current git branch.
+
+    Uses ``gh pr view`` which resolves the current branch to its open PR.
+
+    Returns:
+        The PR number.
+
+    Raises:
+        GhError: If no PR is associated with the current branch.
+    """
+    raw = run_gh("pr", "view", "--json", "number", "-q", ".number", cwd=cwd)
+    return int(raw.strip())
+
+
 def get_repo_info(cwd: str | None = None) -> tuple[str, str]:
     """Get the owner and repo name for the current repository.
 

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -17,6 +17,7 @@ from codereviewbuddy.gh import (
     GhNotAuthenticatedError,
     GhNotFoundError,
     check_auth,
+    get_current_pr_number,
     get_repo_info,
     graphql,
     rest,
@@ -168,6 +169,17 @@ class TestCheckAuth:
         _patch_run(mocker, stderr="not logged in", returncode=1)
         with pytest.raises(GhNotAuthenticatedError):
             check_auth()
+
+
+class TestGetCurrentPrNumber:
+    def test_success(self, mocker: MockerFixture):
+        _patch_run(mocker, stdout="42\n")
+        assert get_current_pr_number() == 42
+
+    def test_no_pr_for_branch(self, mocker: MockerFixture):
+        _patch_run(mocker, stderr="no pull requests found", returncode=1)
+        with pytest.raises(GhError, match="no pull requests found"):
+            get_current_pr_number()
 
 
 class TestGetRepoInfo:

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -135,8 +135,8 @@ class TestToolRegistration:
         tool = next(t for t in tools if t.name == "list_review_comments")
         schema = tool.inputSchema
         assert "pr_number" in schema["properties"]
-        assert schema["properties"]["pr_number"]["type"] == "integer"
-        assert "pr_number" in schema["required"]
+        # pr_number is optional (int | None) — not in required
+        assert "pr_number" not in schema.get("required", [])
 
     async def test_resolve_comment_schema(self, client: Client):
         tools = await client.list_tools()
@@ -149,9 +149,9 @@ class TestToolRegistration:
         tools = await client.list_tools()
         tool = next(t for t in tools if t.name == "request_rereview")
         schema = tool.inputSchema
-        # reviewer and repo are optional
+        # all params are optional
         required = schema.get("required", [])
-        assert "pr_number" in required
+        assert "pr_number" not in required
         assert "reviewer" not in required
         assert "repo" not in required
 


### PR DESCRIPTION
## Summary

Make `pr_number` optional across all MCP tools by auto-detecting it from the current git branch via `gh pr view --json number`.

Closes #71

## Changes

- **`gh.get_current_pr_number()`**: New helper that runs `gh pr view --json number` to detect the PR for the current branch
- **`server._resolve_pr_number()`**: Resolves `pr_number: int | None` — returns it as-is if provided, auto-detects if `None`
- **All tool signatures updated**: `pr_number` is now `int | None = None` across `list_review_comments`, `list_stack_review_comments`, `resolve_comment`, `resolve_stale_comments`, `reply_to_comment`, `request_rereview`, and `create_issue_from_comment`
- **Docstrings updated**: All `pr_number` args now say "Auto-detected from current branch if omitted"

## Why

Agents working on the current branch shouldn't need to manually look up the PR number. This removes friction from the most common workflow — reviewing comments on the branch you're already on.

## Tests

- `TestGetCurrentPrNumber`: success + no-PR-for-branch error
- `TestResolvePrNumber`: explicit number passthrough, auto-detect, and error propagation
- Schema tests updated: `pr_number` is no longer in `required` fields

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
