### PR TITLE
build: copier update to 0.20.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.20.3
+_commit: 0.20.4
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - name: Checkout
+    - name: Checkout release tag
       uses: actions/checkout@v6
       with:
-        ref: main
-        fetch-tags: true
+        ref: ${{ needs.release.outputs.version }}
     - name: Setup uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,8 +1,8 @@
 # Lychee link checker configuration
 # https://github.com/lycheeverse/lychee
 
-# Don't check the config file itself, test fixtures, or Jinja2 template overrides
-exclude_path = [".lychee.toml", "tests/", "docs/.overrides/"]
+# Don't check the config file itself (regex patterns get parsed as URLs)
+exclude_path = [".lychee.toml", "docs/.overrides/"]
 
 # Exclude placeholder and example URLs
 exclude = [

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -21,3 +21,6 @@ MD041: false
 
 # Allow duplicate headings with different content (e.g., "Description" in multiple sections)
 MD024: false
+
+# Allow blank lines between consecutive blockquotes (used for callout boxes in README)
+MD028: false

--- a/prek.toml
+++ b/prek.toml
@@ -1,6 +1,7 @@
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.2"
-default_install_hook_types = ["commit-msg", "post-checkout", "post-commit", "post-merge", "post-rewrite", "pre-commit", "pre-merge-commit", "pre-push", "pre-rebase", "prepare-commit-msg"]
+# All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
+default_install_hook_types = ["commit-msg", "pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"
@@ -65,7 +66,7 @@ hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
 rev = "lychee-v0.22.0"  # pinned: 'nightly' tag is mutable, update manually
-hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1 }]
+hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
 repo = "local"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101"]  # Allow assert in tests
+"tests/**" = ["S101", "S603", "S607", "S701", "T201"]  # Allow assert, subprocess, jinja2, print in tests
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
@@ -155,7 +155,6 @@ markers = [
 ]
 filterwarnings = [
     "error",
-    "error::EncodingWarning",
 ]
 
 [tool.coverage.run]
@@ -182,7 +181,7 @@ setup = "uv sync"
 # Quality checks
 lint = "ruff check ."
 format = "ruff format ."
-typecheck = "ty check src"
+typecheck = "ty check ."
 
 # Combined tasks
 check = ["lint", "typecheck"]
@@ -203,6 +202,8 @@ verify-scaffold = "bash scripts/verify-scaffold.sh"
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 
 # GitHub utilities
+# actions-up: https://github.com/azat-io/actions-up
+actionsup = "actions-up"
 releases = "gh release list --limit 10"
 runs = "gh run list --limit 10"
 checks = "gh pr checks --watch"


### PR DESCRIPTION
## Summary

Copier template update from 0.20.3 → 0.20.4. Resolved 2 merge conflicts (`.lychee.toml`, `prek.toml`).

## Changes

- **release.yml**: Checkout the exact release tag in pypi-publish instead of `main` (fixes tag-checkout race condition)
- **prek.toml**: Narrow `default_install_hook_types` to only `commit-msg`, `pre-commit`, `pre-push` (was all 10 hook types)
- **.lychee.toml**: Remove `tests/` from `exclude_path` (no longer needed — test URLs excluded by pattern)
- **pyproject.toml**: Broader test lint ignores (`S603`, `S607`, `S701`, `T201`), `ty check .` instead of `ty check src`, removed duplicate `error::EncodingWarning` filterwarning
- **.markdownlint.yaml**: Allow blank lines between blockquotes (MD028)
- **pyproject.toml**: Add `actionsup` poe task

## Conflict resolutions

- **`.lychee.toml`**: Took template version — removed `tests/` from `exclude_path`
- **`prek.toml`**: Took template version — narrowed `default_install_hook_types` to 3 hooks
