### PR TITLE
feat: review and update PR descriptions with config control (#15)

### DIFF
--- a/src/codereviewbuddy/middleware.py
+++ b/src/codereviewbuddy/middleware.py
@@ -26,6 +26,7 @@ WRITE_TOOLS = frozenset({
     "reply_to_comment",
     "request_rereview",
     "create_issue_from_comment",
+    "update_pr_description",
 })
 
 RAPID_WRITE_THRESHOLD = 4

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -105,6 +105,38 @@ class UpdateCheckResult(BaseModel):
     error: str | None = Field(default=None, description="Error message if the request failed")
 
 
+class PRDescriptionInfo(BaseModel):
+    """A single PR's description with quality analysis."""
+
+    pr_number: int = Field(description="PR number")
+    title: str = Field(description="PR title")
+    body: str = Field(default="", description="PR body/description")
+    url: str = Field(default="", description="PR URL")
+    has_body: bool = Field(default=False, description="Whether the PR has a non-empty description")
+    is_boilerplate: bool = Field(default=False, description="Whether the description is template boilerplate only")
+    linked_issues: list[str] = Field(default_factory=list, description="Issue references found (e.g. #123)")
+    missing_elements: list[str] = Field(
+        default_factory=list, description="Missing quality elements (e.g. 'no linked issues', 'empty body')"
+    )
+
+
+class PRDescriptionReviewResult(BaseModel):
+    """Result of reviewing PR descriptions across a stack."""
+
+    descriptions: list[PRDescriptionInfo] = Field(default_factory=list, description="PR descriptions with analysis")
+    error: str | None = Field(default=None, description="Error message if the request failed")
+
+
+class UpdatePRDescriptionResult(BaseModel):
+    """Result of updating a PR description."""
+
+    pr_number: int = Field(default=0, description="PR number that was updated")
+    updated: bool = Field(default=False, description="Whether the description was actually updated")
+    requires_review: bool = Field(default=False, description="True if config requires user review before applying")
+    preview: str = Field(default="", description="Preview of the new body (when require_review is true)")
+    error: str | None = Field(default=None, description="Error message if the request failed")
+
+
 class CreateIssueResult(BaseModel):
     """Result of creating a GitHub issue from a review comment."""
 

--- a/src/codereviewbuddy/tools/descriptions.py
+++ b/src/codereviewbuddy/tools/descriptions.py
@@ -1,0 +1,184 @@
+"""MCP tools for reviewing and updating PR descriptions."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from fastmcp.utilities.async_utils import call_sync_fn_in_threadpool
+
+from codereviewbuddy import gh
+from codereviewbuddy.config import get_config
+from codereviewbuddy.models import PRDescriptionInfo, PRDescriptionReviewResult, UpdatePRDescriptionResult
+
+if TYPE_CHECKING:
+    from fastmcp.server.context import Context
+
+# Common boilerplate patterns found in PR description templates
+_BOILERPLATE_PATTERNS = [
+    r"<!-- Brief description",
+    r"<!-- Link related issues",
+    r"\[[ x]?\]\s*Tests added",
+    r"\[[ x]?\]\s*Documentation updated",
+    r"\[[ x]?\]\s*Commit messages follow",
+    r"## Description\s*\n\s*\n\s*##",  # Empty description section
+    r"## Checklist",
+]
+
+# Pattern for issue references: #123, org/repo#123
+_ISSUE_REF_PATTERN = re.compile(
+    r"(?:(?:closes?|fixes?|resolves?)\s+)?(?:[\w.-]+/[\w.-]+)?#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _fetch_pr_info(pr_number: int, repo: str | None = None, cwd: str | None = None) -> dict:
+    """Fetch PR title, body, and URL via gh CLI."""
+    args = ["pr", "view", str(pr_number), "--json", "number,title,body,url"]
+    if repo:
+        args.extend(["--repo", repo])
+    import json
+
+    raw = gh.run_gh(*args, cwd=cwd)
+    return json.loads(raw)
+
+
+def _is_boilerplate(body: str) -> bool:
+    """Check if the body is mostly template boilerplate."""
+    if not body.strip():
+        return True
+    # Strip HTML comments and checklist items, see what's left
+    stripped = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+    stripped = re.sub(r"- \[[ x]?\].*", "", stripped)
+    stripped = re.sub(r"^#{1,6}\s+.*", "", stripped, flags=re.MULTILINE)
+    stripped = stripped.strip()
+    # If very little remains after stripping, it's boilerplate
+    if len(stripped) < 20:
+        return True
+    # Check for known boilerplate patterns
+    matches = sum(1 for p in _BOILERPLATE_PATTERNS if re.search(p, body, re.IGNORECASE))
+    return matches >= 3
+
+
+def _analyze_pr(data: dict) -> PRDescriptionInfo:
+    """Analyze a PR's description quality."""
+    body = data.get("body", "") or ""
+    title = data.get("title", "")
+    pr_number = data.get("number", 0)
+    url = data.get("url", "")
+
+    has_body = bool(body.strip())
+    boilerplate = _is_boilerplate(body) if has_body else False
+    body_no_comments = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+    issue_refs = _ISSUE_REF_PATTERN.findall(body_no_comments)
+
+    missing: list[str] = []
+    if not has_body:
+        missing.append("empty body")
+    elif boilerplate:
+        missing.append("body is template boilerplate only")
+    if not issue_refs:
+        missing.append("no linked issues")
+    if len(body.strip()) < 50 and has_body and not boilerplate:
+        missing.append("description is very short")
+
+    return PRDescriptionInfo(
+        pr_number=pr_number,
+        title=title,
+        body=body,
+        url=url,
+        has_body=has_body,
+        is_boilerplate=boilerplate,
+        linked_issues=[f"#{ref}" for ref in issue_refs],
+        missing_elements=missing,
+    )
+
+
+async def review_pr_descriptions(
+    pr_numbers: list[int],
+    repo: str | None = None,
+    ctx: Context | None = None,
+) -> PRDescriptionReviewResult:
+    """Fetch and analyze PR descriptions for quality issues.
+
+    Args:
+        pr_numbers: List of PR numbers to review.
+        repo: Repository in "owner/repo" format. Auto-detected if not provided.
+        ctx: FastMCP context for progress reporting.
+
+    Returns:
+        Analysis results for each PR's description.
+    """
+    config = get_config()
+    if not config.pr_descriptions.enabled:
+        return PRDescriptionReviewResult(error="PR description tools are disabled in config")
+
+    descriptions: list[PRDescriptionInfo] = []
+    total = len(pr_numbers)
+
+    for i, pr_number in enumerate(pr_numbers):
+        if ctx:
+            await ctx.report_progress(i, total)
+        data = await call_sync_fn_in_threadpool(_fetch_pr_info, pr_number, repo=repo)
+        descriptions.append(_analyze_pr(data))
+
+    if ctx:
+        await ctx.report_progress(total, total)
+        await ctx.info(f"Reviewed {total} PR description(s)")
+
+    return PRDescriptionReviewResult(descriptions=descriptions)
+
+
+async def update_pr_description(
+    pr_number: int,
+    body: str,
+    repo: str | None = None,
+    ctx: Context | None = None,
+) -> UpdatePRDescriptionResult:
+    """Update a PR's description.
+
+    Respects config settings:
+    - If ``pr_descriptions.enabled`` is false, returns an error.
+    - If ``pr_descriptions.require_review`` is true, returns a preview
+      instead of applying the update. The agent should present the
+      preview to the user for approval.
+
+    Args:
+        pr_number: PR number to update.
+        body: New description body.
+        repo: Repository in "owner/repo" format. Auto-detected if not provided.
+        ctx: FastMCP context for logging.
+
+    Returns:
+        Update result with status and optional preview.
+    """
+    config = get_config()
+    if not config.pr_descriptions.enabled:
+        return UpdatePRDescriptionResult(
+            pr_number=pr_number,
+            error="PR description tools are disabled in config",
+        )
+
+    if config.pr_descriptions.require_review:
+        if ctx:
+            await ctx.info(f"PR #{pr_number}: require_review is on \u2014 returning preview for user approval")
+        return UpdatePRDescriptionResult(
+            pr_number=pr_number,
+            updated=False,
+            requires_review=True,
+            preview=body,
+        )
+
+    # Apply the update
+    args = ["pr", "edit", str(pr_number), "--body", body]
+    if repo:
+        args.extend(["--repo", repo])
+    await call_sync_fn_in_threadpool(gh.run_gh, *args)
+
+    if ctx:
+        await ctx.info(f"Updated description for PR #{pr_number}")
+
+    return UpdatePRDescriptionResult(
+        pr_number=pr_number,
+        updated=True,
+    )

--- a/tests/test_descriptions.py
+++ b/tests/test_descriptions.py
@@ -1,0 +1,234 @@
+"""Tests for PR description review and update tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from codereviewbuddy.config import Config, PRDescriptionsConfig, set_config
+from codereviewbuddy.tools.descriptions import (
+    _analyze_pr,
+    _is_boilerplate,
+    review_pr_descriptions,
+    update_pr_description,
+)
+
+# -- Fixtures ------------------------------------------------------------------
+
+GOOD_PR = {
+    "number": 42,
+    "title": "feat: add PR description tools",
+    "body": (
+        "## Summary\n\nAdd tools for reviewing and updating PR descriptions."
+        "\n\nCloses #15\n\n## Changes\n\n- Added review_pr_descriptions\n- Added update_pr_description"
+    ),
+    "url": "https://github.com/owner/repo/pull/42",
+}
+
+EMPTY_PR = {
+    "number": 10,
+    "title": "fix: something",
+    "body": "",
+    "url": "https://github.com/owner/repo/pull/10",
+}
+
+BOILERPLATE_PR = {
+    "number": 20,
+    "title": "chore: cleanup",
+    "body": (
+        "## Description\n\n<!-- Brief description of what this PR does -->\n\n"
+        "## Checklist\n\n- [ ] Tests added/updated\n- [ ] Documentation updated (if applicable)\n"
+        "- [ ] `poe check` passes\n"
+        "- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)\n\n"
+        "## Related Issues\n\n<!-- Link related issues: Fixes #123, Related to #456 -->\n"
+    ),
+    "url": "https://github.com/owner/repo/pull/20",
+}
+
+SHORT_PR = {
+    "number": 30,
+    "title": "docs: typo fix",
+    "body": "Fixed a typo in README.",
+    "url": "https://github.com/owner/repo/pull/30",
+}
+
+
+# -- Unit tests: _is_boilerplate -----------------------------------------------
+
+
+class TestIsBoilerplate:
+    def test_empty_string_is_boilerplate(self):
+        assert _is_boilerplate("") is True
+
+    def test_whitespace_only_is_boilerplate(self):
+        assert _is_boilerplate("   \n\n  ") is True
+
+    def test_template_checklist_is_boilerplate(self):
+        assert _is_boilerplate(str(BOILERPLATE_PR["body"])) is True
+
+    def test_real_description_is_not_boilerplate(self):
+        assert _is_boilerplate(str(GOOD_PR["body"])) is False
+
+    def test_short_description_is_not_boilerplate(self):
+        assert _is_boilerplate("Fixed a typo in README.") is False
+
+    def test_unchecked_checkbox_boilerplate(self):
+        body = (
+            "<!-- Brief description -->\n"
+            "## Checklist\n"
+            "- [ ] Tests added\n"
+            "- [ ] Documentation updated\n"
+            "- [ ] Commit messages follow convention\n"
+            "<!-- Link related issues -->\n"
+        )
+        assert _is_boilerplate(body) is True
+
+    def test_multiword_headings_stripped(self):
+        body = "## Related Issues\n\n## Breaking Changes\n\n## Additional Notes\n\n"
+        assert _is_boilerplate(body) is True
+
+
+# -- Unit tests: _analyze_pr ---------------------------------------------------
+
+
+class TestAnalyzePR:
+    def test_good_pr(self):
+        info = _analyze_pr(GOOD_PR)
+        assert info.pr_number == 42
+        assert info.has_body is True
+        assert info.is_boilerplate is False
+        assert "#15" in info.linked_issues
+        assert info.missing_elements == []
+
+    def test_empty_pr(self):
+        info = _analyze_pr(EMPTY_PR)
+        assert info.has_body is False
+        assert "empty body" in info.missing_elements
+        assert "no linked issues" in info.missing_elements
+
+    def test_boilerplate_pr(self):
+        info = _analyze_pr(BOILERPLATE_PR)
+        assert info.has_body is True
+        assert info.is_boilerplate is True
+        assert "body is template boilerplate only" in info.missing_elements
+        assert info.linked_issues == []  # HTML comment placeholders should not count
+        assert "no linked issues" in info.missing_elements
+
+    def test_short_pr_no_issues(self):
+        info = _analyze_pr(SHORT_PR)
+        assert info.has_body is True
+        assert info.is_boilerplate is False
+        assert "no linked issues" in info.missing_elements
+        assert "description is very short" in info.missing_elements
+
+    def test_multiple_issue_refs(self):
+        data = {
+            "number": 1,
+            "title": "feat: big change",
+            "body": "Closes #10, fixes #20, related to org/repo#30",
+            "url": "",
+        }
+        info = _analyze_pr(data)
+        assert "#10" in info.linked_issues
+        assert "#20" in info.linked_issues
+        assert "#30" in info.linked_issues
+
+
+# -- Async tests: review_pr_descriptions --------------------------------------
+
+
+class TestReviewPRDescriptions:
+    @pytest.fixture(autouse=True)
+    def _reset_config(self):
+        set_config(Config())
+        yield
+        set_config(Config())
+
+    async def test_reviews_multiple_prs(self, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.tools.descriptions._fetch_pr_info",
+            side_effect=[GOOD_PR, EMPTY_PR],
+        )
+        result = await review_pr_descriptions([42, 10])
+        assert result.error is None
+        assert len(result.descriptions) == 2
+        assert result.descriptions[0].pr_number == 42
+        assert result.descriptions[1].pr_number == 10
+        assert result.descriptions[1].has_body is False
+
+    async def test_reports_progress(self, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.tools.descriptions._fetch_pr_info",
+            return_value=GOOD_PR,
+        )
+        ctx = AsyncMock()
+        result = await review_pr_descriptions([42], ctx=ctx)
+        assert result.error is None
+        ctx.report_progress.assert_any_call(0, 1)
+        ctx.report_progress.assert_any_call(1, 1)
+        ctx.info.assert_called_once()
+
+    async def test_disabled_returns_error(self):
+        set_config(Config(pr_descriptions=PRDescriptionsConfig(enabled=False)))
+        result = await review_pr_descriptions([42])
+        assert result.error is not None
+        assert "disabled" in result.error
+
+
+# -- Async tests: update_pr_description ----------------------------------------
+
+
+class TestUpdatePRDescription:
+    @pytest.fixture(autouse=True)
+    def _reset_config(self):
+        set_config(Config())
+        yield
+        set_config(Config())
+
+    async def test_updates_description(self, mocker: MockerFixture):
+        mock_run = mocker.patch("codereviewbuddy.tools.descriptions.gh.run_gh")
+        result = await update_pr_description(42, "New body text")
+        assert result.updated is True
+        assert result.requires_review is False
+        assert result.error is None
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0]
+        assert "pr" in call_args
+        assert "edit" in call_args
+        assert "42" in call_args
+        assert "New body text" in call_args
+
+    async def test_with_repo(self, mocker: MockerFixture):
+        mock_run = mocker.patch("codereviewbuddy.tools.descriptions.gh.run_gh")
+        result = await update_pr_description(42, "Body", repo="other/repo")
+        assert result.updated is True
+        call_args = mock_run.call_args[0]
+        assert "other/repo" in call_args
+
+    async def test_disabled_returns_error(self):
+        set_config(Config(pr_descriptions=PRDescriptionsConfig(enabled=False)))
+        result = await update_pr_description(42, "Body")
+        assert result.updated is False
+        assert result.error is not None
+        assert "disabled" in result.error
+
+    async def test_require_review_returns_preview(self):
+        set_config(Config(pr_descriptions=PRDescriptionsConfig(require_review=True)))
+        ctx = AsyncMock()
+        result = await update_pr_description(42, "## Summary\n\nNew description", ctx=ctx)
+        assert result.updated is False
+        assert result.requires_review is True
+        assert result.preview == "## Summary\n\nNew description"
+        assert result.error is None
+        ctx.info.assert_called_once()
+
+    async def test_require_review_does_not_call_gh(self, mocker: MockerFixture):
+        set_config(Config(pr_descriptions=PRDescriptionsConfig(require_review=True)))
+        mock_run = mocker.patch("codereviewbuddy.tools.descriptions.gh.run_gh")
+        await update_pr_description(42, "Body")
+        mock_run.assert_not_called()

--- a/tests/test_write_middleware.py
+++ b/tests/test_write_middleware.py
@@ -38,6 +38,7 @@ class TestWriteToolClassification:
             "reply_to_comment",
             "request_rereview",
             "create_issue_from_comment",
+            "update_pr_description",
         }
         assert expected == WRITE_TOOLS
 


### PR DESCRIPTION
## Summary

Add two new MCP tools for PR description management, gated by a new `[pr_descriptions]` config section. Refactors the CLI to `codereviewbuddy config --init / --update` so existing users can pick up new config sections without recreating their config file.

Closes #15

## New Tools

### `review_pr_descriptions(pr_numbers, repo?)`
Analyzes PR descriptions across a stack for quality issues — empty body, boilerplate-only, missing linked issues, too short.

### `update_pr_description(body, pr_number?, repo?)`
Updates a PR's description via `gh pr edit`. Respects config:
- **`enabled`**: Set to `false` to disable description tools entirely
- **`require_review`**: Set to `true` to return a preview instead of applying

## Config

```toml
[pr_descriptions]
# enabled = true        # set to false to disable PR description tools entirely
# require_review = false # set to true to require user approval before updating
```

## CLI Refactor

- `codereviewbuddy config --init` — creates a new `.codereviewbuddy.toml` with all default sections
- `codereviewbuddy config --update` — appends missing sections to an existing config without overwriting user values

## Tests

- Unit: boilerplate detection, PR analysis, async tool functions
- MCP integration: tool registration, schema validation, end-to-end calls
- Config CLI: init, update, error hints
- Write middleware: `update_pr_description` added to `WRITE_TOOLS`
- 288 tests passing, 94.74% coverage
