### PR TITLE
fix: configurable rereview messages and agent reply instructions (#77, #78)

### DIFF
--- a/.codereviewbuddy.toml
+++ b/.codereviewbuddy.toml
@@ -22,3 +22,9 @@ resolve_levels = ["info"]       # Only allow resolving info-level threads from D
 # enabled = true
 # auto_resolve_stale = false      # CodeRabbit handles its own resolution
 # resolve_levels = []             # Don't resolve any CodeRabbit threads
+
+# --- New sections added by 'codereviewbuddy config --update' ---
+
+[pr_descriptions]
+enabled = true                  # Set to false to disable PR description tools entirely
+require_review = false          # Set to true to require user approval before updating descriptions

--- a/src/codereviewbuddy/config.py
+++ b/src/codereviewbuddy/config.py
@@ -40,6 +40,7 @@ _REVIEWER_DEFAULTS: dict[str, dict[str, Any]] = {
         "enabled": True,
         "auto_resolve_stale": True,  # We batch-resolve Unblocked's stale threads
         "resolve_levels": [Severity.INFO, Severity.WARNING, Severity.FLAGGED, Severity.BUG],
+        # rereview_message intentionally omitted — None means "use adapter default"
     },
     "coderabbit": {
         "enabled": True,
@@ -60,6 +61,11 @@ class ReviewerConfig(BaseModel):
     resolve_levels: list[Severity] = Field(
         default_factory=lambda: list(Severity),
         description="Severity levels that are allowed to be resolved",
+    )
+    rereview_message: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Custom message to post when triggering a re-review (only for manual-trigger reviewers)",
     )
 
 
@@ -230,6 +236,7 @@ _TEMPLATE_SECTIONS: list[tuple[str, str]] = [
 # enabled = true
 # auto_resolve_stale = true       # We batch-resolve Unblocked's stale threads
 # resolve_levels = ["info", "warning", "flagged", "bug"]  # All levels allowed
+# rereview_message = "@unblocked please re-review"  # Message posted to trigger re-review
 """,
     ),
     (

--- a/src/codereviewbuddy/reviewers/unblocked.py
+++ b/src/codereviewbuddy/reviewers/unblocked.py
@@ -30,6 +30,9 @@ class UnblockedAdapter(ReviewerAdapter):
         return normalized in {"unblocked[bot]", "unblocked-bot", "unblocked"}
 
     def rereview_trigger(self, pr_number: int, owner: str, repo: str) -> list[str]:
+        message = "@unblocked please re-review"
+        if self._config and self._config.rereview_message is not None:
+            message = self._config.rereview_message
         return [
             "pr",
             "comment",
@@ -37,5 +40,5 @@ class UnblockedAdapter(ReviewerAdapter):
             "--repo",
             f"{owner}/{repo}",
             "--body",
-            "@unblocked please re-review",
+            message,
         ]

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -79,13 +79,19 @@ PR's latest commit timestamp. If a reviewer posted before the latest push, their
 is "pending". Only reviewers that have actually commented on the PR are tracked — we
 don't assume which reviewers are installed.
 
+## Responding to review comments
+
+Always reply to bug (🔴) and flagged (🚩) level comments with `reply_to_comment`
+explaining what you fixed, the commit hash, and any regression test added. Do not
+silently push — reviewers need to see that their finding was acknowledged. For info
+(📝) and warning (🟡) comments, a reply is optional but appreciated when you made
+changes based on them.
+
 ## Reviewer behavior differences
 
-- **Unblocked**: Does NOT auto-review on new pushes. You MUST call `request_rereview`
-  (which posts "@unblocked please re-review") after pushing fixes.
-- **Devin**: Auto-triggers a new review on every push. No action needed, but you can
-  still call `request_rereview` if you want to force one.
-- **CodeRabbit**: Auto-triggers on push. Same as Devin — no action needed.
+Some reviewers auto-trigger a new review on every push (e.g. Devin, CodeRabbit) while
+others require a manual trigger via `request_rereview` (e.g. Unblocked). The trigger
+message is configurable per-reviewer via `rereview_message` in `.codereviewbuddy.toml`.
 
 ## Staleness
 
@@ -283,10 +289,10 @@ async def request_rereview(
 ) -> RereviewResult:
     """Trigger a re-review for AI reviewers on a PR.
 
-    Handles per-reviewer differences automatically:
-    - Unblocked: posts "@unblocked please re-review" comment (manual trigger needed)
-    - Devin: auto-triggers on push (no action needed)
-    - CodeRabbit: auto-triggers on push (no action needed)
+    Handles per-reviewer differences automatically. Reviewers that need manual
+    triggers get a configurable comment posted (see ``rereview_message`` in
+    ``.codereviewbuddy.toml``). Reviewers that auto-trigger on push are reported
+    as needing no action.
 
     Args:
         pr_number: PR number. Auto-detected from current branch if omitted.

--- a/tests/test_reviewers.py
+++ b/tests/test_reviewers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from codereviewbuddy.config import Severity
+from codereviewbuddy.config import ReviewerConfig, Severity
 from codereviewbuddy.reviewers import (
     REVIEWERS,
     CodeRabbitAdapter,
@@ -52,12 +52,24 @@ class TestUnblockedAdapter:
         assert adapter.needs_manual_rereview is True
         assert adapter.auto_resolves_comments is False
 
-    def test_rereview_trigger(self):
+    def test_rereview_trigger_default_message(self):
         adapter = UnblockedAdapter()
         args = adapter.rereview_trigger(42, "owner", "repo")
         assert args[0] == "pr"
         assert "42" in args
         assert "--body" in args
+        assert "@unblocked please re-review" in args
+
+    def test_rereview_trigger_custom_message(self):
+        adapter = UnblockedAdapter()
+        adapter.configure(ReviewerConfig(rereview_message="@unblocked re-review please, with context"))
+        args = adapter.rereview_trigger(42, "owner", "repo")
+        assert "@unblocked re-review please, with context" in args
+
+    def test_rereview_trigger_config_without_message_uses_default(self):
+        adapter = UnblockedAdapter()
+        adapter.configure(ReviewerConfig())
+        args = adapter.rereview_trigger(42, "owner", "repo")
         assert "@unblocked please re-review" in args
 
 


### PR DESCRIPTION
## Summary

Fixes two issues to improve agent behavior and reviewer configurability.

Closes #77
Closes #78

## Changes

### #78: Instruct agents to reply to bug-level comments

Added a "Responding to review comments" section to the MCP server `instructions`. Agents are now guided to:
- **Always reply** to bug (🔴) and flagged (🚩) comments with fix details and commit hash
- Optionally reply to info (📝) and warning (🟡) when changes were made

### #77: Configurable rereview trigger messages

- Added `rereview_message` field to `ReviewerConfig` (default: `None`, uses adapter default)
- `UnblockedAdapter.rereview_trigger()` now reads from config instead of hardcoding
- Updated `.codereviewbuddy.toml` template with the new option
- Removed hardcoded reviewer names from `request_rereview` tool docstring and server instructions

## Config

```toml
[reviewers.unblocked]
rereview_message = "@unblocked please re-review"  # customizable
```

## Tests

- `test_rereview_trigger_custom_message` — config overrides default
- `test_rereview_trigger_config_without_message_uses_default` — None falls through
- 292 tests passing, 94.78% coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
