### PR TITLE
feat: config deprecation handling — warn, comment out, clean

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=3.0.0b2",
+    "tomlkit>=0.13",
 ]
 
 [project.scripts]

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -438,18 +438,21 @@ def main() -> None:
 
 
 def _config_cmd(args: list[str]) -> None:
-    """Handle ``codereviewbuddy config [--init | --update]``."""
-    from codereviewbuddy.config import init_config, update_config
+    """Handle ``codereviewbuddy config [--init | --update | --clean]``."""
+    from codereviewbuddy.config import clean_config, init_config, update_config
 
     if "--init" in args:
         init_config()
     elif "--update" in args:
         update_config()
+    elif "--clean" in args:
+        clean_config()
     else:
-        print("Usage: codereviewbuddy config [--init | --update]")  # noqa: T201
+        print("Usage: codereviewbuddy config [--init | --update | --clean]")  # noqa: T201
         print()  # noqa: T201
         print("  --init    Create a new .codereviewbuddy.toml with all defaults")  # noqa: T201
-        print("  --update  Add new config sections without changing existing values")  # noqa: T201
+        print("  --update  Add new sections and comment out deprecated keys")  # noqa: T201
+        print("  --clean   Remove deprecated keys entirely")  # noqa: T201
         raise SystemExit(1)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,7 @@ version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "tomlkit" },
 ]
 
 [package.dev-dependencies]
@@ -244,7 +245,10 @@ maintain = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastmcp", specifier = ">=3.0.0b2" }]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.0.0b2" },
+    { name = "tomlkit", specifier = ">=0.13" },
+]
 
 [package.metadata.requires-dev]
 ci = [


### PR DESCRIPTION
## Description

Gracefully handle deprecated/unknown config keys in `.codereviewbuddy.toml`:

### Load-time Warnings
When loading config, unknown keys are detected by recursively comparing TOML data against the Pydantic model fields. Unknown reviewer *names* under `[reviewers.*]` are intentionally allowed (forward-compat), but unknown *keys within* known sections are flagged with a warning pointing users to `--update`.

### CLI Commands
- **`config --update`** — Comments out deprecated keys (style-preserving via `tomlkit`) and appends any missing new sections. The commented keys show as `# DEPRECATED: key = value` so users can see what was removed.
- **`config --clean`** — Removes deprecated keys entirely (no comments left behind).

### Bug Fix (from review)
Fixed `IndexError` crash when an unknown key is a TOML table (e.g. empty `[old_section]`). Table values are now serialized via `tomlkit.inline_table()` with a `repr()` fallback.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

Part of #64 (per-reviewer configuration system — config management portion)