### PR TITLE
build: copier update from ci-components template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.20.4
+_commit: 0.22.1
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -28,7 +28,8 @@ exclude_all_private = true
 include_mail = false
 
 # Accept common status codes
-accept = [200, 204, 301, 302, 403, 429]
+# 502: GitHub commit/release URLs transiently return Bad Gateway
+accept = [200, 204, 301, 302, 403, 429, 502]
 
 # Timeout per request
 timeout = 30

--- a/prek.toml
+++ b/prek.toml
@@ -1,7 +1,7 @@
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.2"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
-default_install_hook_types = ["commit-msg", "pre-commit", "pre-push"]
+default_install_hook_types = ["commit-msg", "post-checkout", "pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"
@@ -108,6 +108,15 @@ language = "system"
 files = { glob = ["docs/**", "mkdocs.yml", "README.md", "CONTRIBUTING.md", "CHANGELOG.md", "src/**"] }
 pass_filenames = false
 stages = ["pre-push"]
+
+[[repos.hooks]]
+id = "check-template-update"
+name = "check for template updates"
+entry = "bash scripts/check-template-update.sh"
+language = "system"
+always_run = true
+pass_filenames = false
+stages = ["post-checkout"]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ ci = [
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
     "ty>=0.0.14",
-    "poethepoet>=0.32",
+    "poethepoet>=0.41",
     "pytest-asyncio>=1.3.0",
     "pytest-mock>=3.15.1",
 ]
@@ -183,7 +183,8 @@ format = "ruff format ."
 typecheck = "ty check ."
 
 # Combined tasks
-check = ["lint", "typecheck"]
+check.parallel = ["lint", "typecheck"]
+check.ignore_fail = "return_non_zero"
 fix = ["lint --fix", "format"]
 
 # Documentation
@@ -196,6 +197,10 @@ prek = "prek run --all-files"
 
 # Template dev
 verify-scaffold = "bash scripts/verify-scaffold.sh"
+
+# Template utilities
+check-template = "bash scripts/check-template-update.sh"
+update-template = "copier update --trust . --skip-answered"
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/scripts/check-template-update.sh
+++ b/scripts/check-template-update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Check if a newer version of the copier template is available.
+# Runs as a post-checkout hook — informational only, never blocks.
+# Set COPIER_CHECK_INTERVAL=900 in .envrc for 15-min checks (default: 86400 = 24h).
+set -euo pipefail
+
+# Skip file-level restores (arg 3 = 0); runs on branch switch, pull, rebase, clone
+[[ "${3:-1}" == "0" ]] && exit 0
+
+# Cooldown: throttle when called as a git hook (3 args); always run for manual poe invocation (0 args)
+check_interval="${COPIER_CHECK_INTERVAL:-86400}"
+cache_dir="/tmp"
+cache_file="${cache_dir}/.copier-template-check-$(echo "$PWD" | (sha1sum 2>/dev/null || shasum) | cut -c1-8)"
+if [[ $# -gt 0 && -f "$cache_file" ]]; then
+  last_check=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  (( now - last_check < check_interval )) && exit 0
+fi
+
+answers=".copier-answers.yml"
+[[ -f "$answers" ]] || exit 0
+
+local_version=$(grep "^_commit:" "$answers" | sed "s/_commit: *//;s/^['\"]//;s/['\"]$//") || true
+src_path=$(grep "^_src_path:" "$answers" | sed "s/_src_path: *//;s/^['\"]//;s/['\"]$//") || true
+
+[[ -z "$local_version" || -z "$src_path" ]] && exit 0
+
+# Only supports GitHub for now — silently exit for other providers
+case "$src_path" in
+  gh:*|https://github.com/*) ;;
+  *) exit 0 ;;
+esac
+
+# Convert copier src_path to GitHub owner/repo
+repo="${src_path#gh:}"
+repo="${repo#https://github.com/}"
+repo="${repo%.git}"
+
+latest=$(curl -s --connect-timeout 3 --max-time 5 \
+  "https://api.github.com/repos/${repo}/releases/latest" \
+  | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//') || true
+
+[[ -z "$latest" ]] && exit 0
+
+# Update cooldown cache after successful API check
+touch "$cache_file"
+
+if [[ "$local_version" != "$latest" ]]; then
+  cyan='\033[0;36m'; yellow='\033[1;33m'; dim='\033[2m'; bold='\033[1m'; reset='\033[0m'
+  echo ""
+  echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}"
+  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered"
+  echo -e "  ${dim}Or:${reset}  poe update-template"
+  echo ""
+fi

--- a/scripts/verify-scaffold.sh
+++ b/scripts/verify-scaffold.sh
@@ -256,8 +256,8 @@ section "Poe Tasks"
 # ---------------------------------------------------------------------------
 
 for task in setup lint format typecheck test test-all test-cov check fix \
-            docs docs-build prek; do
-    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
+            docs docs-build prek check-template update-template; do
+    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "^$task\." pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
         pass "Poe task: $task"
     else
         fail "Poe task missing: $task"

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
-    { name = "poethepoet", specifier = ">=0.32" },
+    { name = "poethepoet", specifier = ">=0.41" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6" },


### PR DESCRIPTION
## Description

Routine copier update from the `ci-components` template. Brings in:

- **`scripts/check-template-update.sh`** — New pre-commit hook that checks if a newer template version is available (informational only, never blocks)
- **`scripts/verify-scaffold.sh`** — Updated to support dotted-key task definitions (e.g. `check.parallel`)
- **`.lychee.toml`** — Accept HTTP 502 for transient GitHub errors on commit/release URLs
- **`prek.toml`** — Updated pre-push check configuration
- **`uv.lock`** — Lock file refresh

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

N/A — template maintenance