### PR TITLE
fix: reply_to_comment 404 — use GraphQL mutation instead of REST (#81)

### DIFF
--- a/.codereviewbuddy.toml
+++ b/.codereviewbuddy.toml
@@ -27,4 +27,4 @@ resolve_levels = ["info"]       # Only allow resolving info-level threads from D
 
 [pr_descriptions]
 enabled = true                  # Set to false to disable PR description tools entirely
-require_review = false          # Set to true to require user approval before updating descriptions
+# DEPRECATED: require_review = false


### PR DESCRIPTION
## Summary

Fix `reply_to_comment` returning 404 for valid `PRRT_` thread IDs by switching from the REST pull review comments API to the GraphQL `addPullRequestReviewThreadReply` mutation.

### Problem

The old implementation looked up the `databaseId` of the first comment in a thread (via GraphQL), then called the REST endpoint `/repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`. This returned 404 for many valid thread IDs — the REST API expects a different ID format than what GraphQL provides.

### Fix

- **PRRT_ threads now short-circuit** before repo info lookup — the GraphQL mutation only needs the thread ID and reply body, not owner/repo.
- **New `_REPLY_TO_THREAD_MUTATION`** uses `addPullRequestReviewThreadReply` which accepts the thread's node ID directly.
- **GraphQL errors** are caught and raised as `GhError` with the server message.
- **Deprecated config key**: `require_review` in `[pr_descriptions]` is commented out with a DEPRECATED marker.

### Tests

- Updated `test_reply_to_inline_thread` to verify the GraphQL mutation path (no REST call, no `get_repo_info` needed).
- Updated `test_inline_thread_not_found_raises` → `test_inline_thread_graphql_error_raises` to test GraphQL error handling.

Fixes #81.