### PR TITLE
feat: add triage_review_comments tool for actionable threads only (#96)

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -140,3 +140,31 @@ class CreateIssueResult(BaseModel):
     issue_url: str = Field(default="", description="URL of the created issue")
     title: str = Field(default="", description="Issue title")
     error: str | None = Field(default=None, description="Error message if the request failed")
+
+
+class TriageItem(BaseModel):
+    """A single review thread that needs agent action."""
+
+    thread_id: str = Field(description="GraphQL node ID (PRRT_...) for replying/resolving")
+    pr_number: int = Field(description="PR number this thread belongs to")
+    file: str | None = Field(default=None, description="File path the comment is on")
+    line: int | None = Field(default=None, description="Line number in the file")
+    reviewer: str = Field(description="Which reviewer posted this (e.g. devin, unblocked)")
+    severity: str = Field(description="Classified severity: bug, flagged, warning, info")
+    title: str = Field(default="", description="Short title extracted from the comment (first bold text)")
+    is_stale: bool = Field(default=False, description="Whether the commented file changed since the review")
+    action: str = Field(
+        description="Suggested action: 'fix' (bug/flagged), 'reply' (info/warning), or 'create_issue' (followup without issue ref)"
+    )
+    snippet: str = Field(default="", description="First 200 chars of the comment body for context")
+
+
+class TriageResult(BaseModel):
+    """Triage result for one or more PRs — only threads needing agent action."""
+
+    items: list[TriageItem] = Field(default_factory=list, description="Threads needing action, ordered by severity (bugs first)")
+    needs_fix: int = Field(default=0, description="Count of threads that need a code fix (bug/flagged)")
+    needs_reply: int = Field(default=0, description="Count of threads that need a reply (info/warning)")
+    needs_issue: int = Field(default=0, description="Count of 'noted for followup' replies missing a GH issue reference")
+    total: int = Field(default=0, description="Total actionable threads")
+    error: str | None = Field(default=None, description="Error message if the request failed")

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -116,6 +116,7 @@ class TestToolRegistration:
         "create_issue_from_comment",
         "review_pr_descriptions",
         "summarize_review_status",
+        "triage_review_comments",
     })
 
     async def test_all_tools_registered(self, client: Client):
@@ -125,7 +126,7 @@ class TestToolRegistration:
 
     async def test_tool_count(self, client: Client):
         tools = await client.list_tools()
-        assert len(tools) == 9
+        assert len(tools) == 10
 
     async def test_list_review_comments_schema(self, client: Client):
         tools = await client.list_tools()

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,321 @@
+"""Tests for triage_review_comments — actionable threads only (#96)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from codereviewbuddy.models import CommentStatus, ReviewComment, ReviewSummary, ReviewThread
+from codereviewbuddy.tools.comments import (
+    _classify_action,
+    _extract_title,
+    _has_followup_without_issue,
+    _has_owner_reply,
+    triage_review_comments,
+)
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def _thread(
+    thread_id: str = "PRRT_1",
+    pr_number: int = 42,
+    reviewer: str = "devin",
+    body: str = "🔴 **Bug: Something is broken**\n\nDetails here.",
+    author: str = "devin-ai-integration[bot]",
+    file: str = "src/main.py",
+    line: int = 10,
+    is_stale: bool = False,
+    is_pr_review: bool = False,
+    extra_comments: list[ReviewComment] | None = None,
+) -> ReviewThread:
+    comments = [
+        ReviewComment(
+            author=author,
+            body=body,
+            created_at=datetime(2026, 2, 6, 10, 0, tzinfo=UTC),
+        ),
+    ]
+    if extra_comments:
+        comments.extend(extra_comments)
+    return ReviewThread(
+        thread_id=thread_id,
+        pr_number=pr_number,
+        status=CommentStatus.UNRESOLVED,
+        file=file,
+        line=line,
+        reviewer=reviewer,
+        comments=comments,
+        is_stale=is_stale,
+        is_pr_review=is_pr_review,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTitle:
+    def test_devin_bug_format(self):
+        assert _extract_title("🔴 **Bug: Missing pagination**\nDetails") == "Missing pagination"
+
+    def test_devin_info_format(self):
+        assert _extract_title("📝 **Info: Consider refactoring**") == "Consider refactoring"
+
+    def test_plain_bold(self):
+        assert _extract_title("**Some title here**\nBody text") == "Some title here"
+
+    def test_no_bold(self):
+        assert _extract_title("No bold text here") == ""
+
+
+class TestHasOwnerReply:
+    def test_owner_present(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Fixed in abc123"),
+            ]
+        )
+        assert _has_owner_reply(thread, frozenset(["ichoosetoaccept"])) is True
+
+    def test_no_owner(self):
+        thread = _thread()
+        assert _has_owner_reply(thread, frozenset(["ichoosetoaccept"])) is False
+
+    def test_different_human(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="humandev", body="Will look into this"),
+            ]
+        )
+        assert _has_owner_reply(thread, frozenset(["ichoosetoaccept"])) is False
+
+    def test_custom_owner_login(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="mybot", body="Addressed"),
+            ]
+        )
+        assert _has_owner_reply(thread, frozenset(["mybot"])) is True
+
+
+class TestHasFollowupWithoutIssue:
+    def test_followup_without_issue(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Noted for followup"),
+            ]
+        )
+        assert _has_followup_without_issue(thread, frozenset(["ichoosetoaccept"])) is True
+
+    def test_followup_with_issue(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Tracked for later in #42"),
+            ]
+        )
+        assert _has_followup_without_issue(thread, frozenset(["ichoosetoaccept"])) is False
+
+    def test_no_followup(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Fixed in abc123"),
+            ]
+        )
+        assert _has_followup_without_issue(thread, frozenset(["ichoosetoaccept"])) is False
+
+    def test_non_owner_followup_ignored(self):
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="someone_else", body="Noted for followup"),
+            ]
+        )
+        assert _has_followup_without_issue(thread, frozenset(["ichoosetoaccept"])) is False
+
+    def test_issue_ref_in_separate_reply(self):
+        """Regression: issue ref in a later comment should clear the followup flag."""
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Noted for followup"),
+                ReviewComment(author="ichoosetoaccept", body="Filed #99"),
+            ]
+        )
+        assert _has_followup_without_issue(thread, frozenset(["ichoosetoaccept"])) is False
+
+
+class TestClassifyAction:
+    def test_bug_needs_fix(self):
+        assert _classify_action("bug") == "fix"
+
+    def test_flagged_needs_fix(self):
+        assert _classify_action("flagged") == "fix"
+
+    def test_warning_needs_reply(self):
+        assert _classify_action("warning") == "reply"
+
+    def test_info_needs_reply(self):
+        assert _classify_action("info") == "reply"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for triage_review_comments
+# ---------------------------------------------------------------------------
+
+
+class TestTriageReviewComments:
+    """Integration tests that mock list_review_comments and verify triage logic."""
+
+    def _mock_list(self, mocker: MockerFixture, threads: list[ReviewThread]) -> AsyncMock:
+        return mocker.patch(
+            "codereviewbuddy.tools.comments.list_review_comments",
+            new_callable=AsyncMock,
+            return_value=ReviewSummary(threads=threads),
+        )
+
+    async def test_unreplied_bug_needs_fix(self, mocker: MockerFixture):
+        """Unreplied bug thread should appear with action='fix'."""
+        bug = _thread(body="🔴 **Bug: Crash on startup**")
+        self._mock_list(mocker, [bug])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 1
+        assert result.needs_fix == 1
+        assert result.items[0].severity == "bug"
+        assert result.items[0].action == "fix"
+        assert result.items[0].title == "Crash on startup"
+
+    async def test_unreplied_info_needs_reply(self, mocker: MockerFixture):
+        """Unreplied info thread should appear with action='reply'."""
+        info = _thread(body="📝 **Info: Consider refactoring**")
+        self._mock_list(mocker, [info])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 1
+        assert result.needs_reply == 1
+        assert result.items[0].severity == "info"
+        assert result.items[0].action == "reply"
+
+    async def test_replied_thread_excluded(self, mocker: MockerFixture):
+        """Thread with an owner reply should not appear in triage."""
+        replied = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Fixed in abc123"),
+            ]
+        )
+        self._mock_list(mocker, [replied])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 0
+
+    async def test_pr_review_excluded(self, mocker: MockerFixture):
+        """PR-level reviews should not appear in triage."""
+        pr_review = _thread(is_pr_review=True)
+        self._mock_list(mocker, [pr_review])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 0
+
+    async def test_followup_without_issue_flagged(self, mocker: MockerFixture):
+        """Owner reply with 'noted for followup' but no issue ref should appear as create_issue."""
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Noted for followup"),
+            ]
+        )
+        self._mock_list(mocker, [thread])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 1
+        assert result.needs_issue == 1
+        assert result.items[0].action == "create_issue"
+
+    async def test_followup_with_issue_excluded(self, mocker: MockerFixture):
+        """Owner reply with 'noted for followup' AND issue ref should be excluded (already handled)."""
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="ichoosetoaccept", body="Tracked for later in #42"),
+            ]
+        )
+        self._mock_list(mocker, [thread])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 0
+
+    async def test_sorted_by_severity(self, mocker: MockerFixture):
+        """Items should be sorted bugs-first."""
+        info = _thread(thread_id="PRRT_info", body="📝 **Info: Minor thing**")
+        bug = _thread(thread_id="PRRT_bug", body="🔴 **Bug: Critical crash**")
+        warning = _thread(thread_id="PRRT_warn", body="🟡 **Warning: Performance**")
+        self._mock_list(mocker, [info, bug, warning])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 3
+        severities = [item.severity for item in result.items if item.action != "create_issue"]
+        assert severities == ["bug", "warning", "info"]
+
+    async def test_multiple_prs(self, mocker: MockerFixture):
+        """Should triage across multiple PRs."""
+        bug_42 = _thread(thread_id="PRRT_42", pr_number=42, body="🔴 **Bug: Issue A**")
+        info_43 = _thread(thread_id="PRRT_43", pr_number=43, body="📝 **Info: Issue B**")
+
+        mock = mocker.patch(
+            "codereviewbuddy.tools.comments.list_review_comments",
+            new_callable=AsyncMock,
+            side_effect=[
+                ReviewSummary(threads=[bug_42]),
+                ReviewSummary(threads=[info_43]),
+            ],
+        )
+
+        result = await triage_review_comments([42, 43], repo="o/r")
+        assert result.total == 2
+        assert result.needs_fix == 1
+        assert result.needs_reply == 1
+        assert mock.call_count == 2
+
+    async def test_empty_pr_list(self):
+        """Empty PR list should return empty triage."""
+        result = await triage_review_comments([], repo="o/r")
+        assert result.total == 0
+        assert result.items == []
+
+    async def test_custom_owner_logins(self, mocker: MockerFixture):
+        """Custom owner_logins should be used for reply detection."""
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="mybot", body="Fixed"),
+            ]
+        )
+        self._mock_list(mocker, [thread])
+
+        # With default owner — thread should appear (mybot isn't ichoosetoaccept)
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 1
+
+        # With custom owner — thread should be excluded
+        result = await triage_review_comments([42], repo="o/r", owner_logins=["mybot"])
+        assert result.total == 0
+
+    async def test_snippet_truncated(self, mocker: MockerFixture):
+        """Snippet should be truncated to 200 chars."""
+        long_body = "🔴 **Bug: Long issue**\n" + "x" * 300
+        thread = _thread(body=long_body)
+        self._mock_list(mocker, [thread])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert len(result.items[0].snippet) == 200
+
+    async def test_stale_flag_preserved(self, mocker: MockerFixture):
+        """is_stale from the underlying thread should be passed through."""
+        stale = _thread(is_stale=True, body="📝 **Info: Old comment**")
+        self._mock_list(mocker, [stale])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.items[0].is_stale is True


### PR DESCRIPTION
## Summary

Add a new `triage_review_comments` MCP tool that returns only threads needing agent action — no noise, no full comment bodies. This is the most-requested workflow improvement: agents no longer need to fetch all threads and manually filter.

Also fixes the followup detection bug where issue refs in separate replies were not correlated across the thread.

## Changes

- **`models.py`**: New `TriageItem` and `TriageResult` models with severity, suggested action, snippet, and title extraction.
- **`tools/comments.py`**: New triage logic:
  - Filters to unresolved inline threads only (excludes PR-level reviews)
  - Excludes threads with an owner reply (`ichoosetoaccept` by default, configurable)
  - Pre-classifies severity using reviewer adapters (🔴 bug → `fix`, 📝 info → `reply`)
  - Extracts title from first bold text (`**Bug: title**` format)
  - Flags "noted for followup" replies missing a GH issue reference → `create_issue` action
  - `_has_followup_without_issue` checks for issue refs across all owner comments in the thread, not per-comment
  - Results sorted by severity (bugs first)
- **`server.py`**: Register tool, update workflow instructions to recommend triage as step 2.
- **`tests/test_triage.py`**: 16 tests covering all filtering, sorting, and edge cases.
- **`tests/test_mcp_integration.py`**: Updated expected tool count (9→10).

## Actions returned per thread

| Severity | Action | Meaning |
|----------|--------|---------|
| 🔴 bug, 🚩 flagged | `fix` | Needs a code change + regression test |
| 🟡 warning, 📝 info | `reply` | Acknowledge with `reply_to_comment` |
| Any (with followup) | `create_issue` | Owner said "noted for followup" but forgot `#N` |

Fixes #96
Closes #106