### PR TITLE
feat: add self-improvement instructions for agent-driven feedback loop (#97)

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -145,6 +145,21 @@ fixed in the PR), use `create_issue_from_comment` to create a GitHub issue. Use 
 to classify: type labels (bug, enhancement, documentation) and priority labels (P0-P3).
 Don't file issues for nitpicks or things already being addressed.
 
+## Self-improvement
+
+If you encounter errors, missing capabilities, or find yourself repeatedly working
+around a limitation of this MCP server, create a GitHub issue describing:
+- What you were trying to do
+- What went wrong or what's missing
+- A proposed solution if you have one
+
+Use `gh issue create` to file the issue against the repo specified in the
+`[self_improvement]` config section. Label it `agent-reported` plus any relevant
+type/priority labels.
+
+This only applies when `[self_improvement]` is enabled in `.codereviewbuddy.toml`
+and a target `repo` is configured. Check the config file before filing.
+
 """,
 )
 


### PR DESCRIPTION
## Summary

Add self-improvement instructions to the MCP server that tell agents to file GitHub issues when they encounter errors, missing capabilities, or repeated workarounds. This creates a feedback loop where the agent — the actual user of the server — reports what would make it better.

Also adds validation that `repo` is non-empty when `enabled=true` in the `[self_improvement]` config section.

## Changes

- **`config.py`**: New `SelfImprovementConfig` model with `enabled` (default `false`) and `repo` fields. Added to top-level `Config` as `[self_improvement]` section. Template section added for `codereviewbuddy config --init/--update`. Model validator ensures `repo` is non-empty when `enabled=true`.
- **`server.py`**: Added "Self-improvement" section to server instructions explaining when and how agents should file issues, gated on the config being enabled.
- **`tests/test_config.py`**: 5 new tests — default values, explicit configuration, TOML loading, validation error, and disabled-without-repo OK.

## Design decisions

- **Opt-in by default**: `enabled = false` — users must explicitly enable this. No surprise issue creation.
- **Repo required**: The agent must know where to file issues. No hardcoded default.
- **Uses `gh issue create`**: Agents use the GitHub CLI — no new dedicated tool needed.
- **`agent-reported` label**: Instructions tell agents to add this label for easy filtering.

Fixes #97
Fixes #109