### PR TITLE
build(template): update copier-uv-bleeding 0.22.1 → 0.26.3

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.22.1
+_commit: 0.26.3
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,17 @@
 # Environment variables for codereviewbuddy
-# Copy this file to .env and fill in your values
+# Copy this file to .env and fill in your values.
 # Never commit .env to version control!
+#
+# .envrc (direnv) sources this file automatically if you add `dotenv` to it.
+# See: https://direnv.net/man/direnv-stdlib.1.html
 
-# Example API keys (uncomment and fill in as needed)
-# API_KEY=your-api-key-here
-# DATABASE_URL=postgresql://user:pass@localhost/db
+# --- Template maintenance ---------------------------------------------------
+
+# How often the post-checkout hook checks for template updates (seconds).
+# Set to 0 to check on every checkout, or comment out for the script default (24 h).
+COPIER_CHECK_INTERVAL=900  # 15 min (set via .envrc)
+
+# --- Application secrets (add your own below) --------------------------------
+
+# API_KEY=
+# DATABASE_URL=

--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,10 @@
 # Requires: https://github.com/direnv/direnv
 export VIRTUAL_ENV="$(pwd)/.venv"
 export PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Uncomment to load .env automatically (secrets stay out of shell history):
+# dotenv_if_exists
+
+# How often the post-checkout hook checks for template updates (seconds).
+# Set to 0 to check on every checkout, or comment out for the script default (24 h).
+export COPIER_CHECK_INTERVAL=900  # 15 min

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,6 +12,11 @@ jobs:
     if: join(github.event.issue.labels.*.name) == ''
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+    - name: Ensure needs-triage label exists
+      run: gh label create "needs-triage" --description "Issue needs triage" --color "FBCA04" || true
+      env:
+        GH_REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Add needs-triage label
       run: gh issue edit "$NUMBER" --add-label "needs-triage"
       env:

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,29 @@
+name: PR Description
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - name: Validate PR description
+      env:
+        BODY: ${{ github.event.pull_request.body }}
+      run: |
+        if [ -z "$BODY" ]; then
+          echo "::error::PR description is empty"
+          exit 1
+        fi
+
+        # Strip HTML comments, headings, checklist lines, and whitespace — what remains is real content
+        content=$(printf '%s\n' "$BODY" | tr -d '\r' | sed '/^<!--.*-->$/d' | sed '/^## /d' | sed '/^- \[[ xX]\]/d' | tr -d '[:space:]')
+        if [ -z "$content" ]; then
+          echo "::error::PR description has no real content — just headings, placeholders, or checklists. Describe your changes."
+          exit 1
+        fi
+
+        echo "✓ PR description looks good"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout release tag
       uses: actions/checkout@v6
       with:
-        ref: ${{ needs.release.outputs.version }}
+        ref: ${{ needs.release.outputs.tag }}
     - name: Setup uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 
 # tools
 .coverage*
+.testmondata
 /.pdm-build/
 /htmlcov/
 /site/

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -1,0 +1,45 @@
+# codereviewbuddy — Template Documentation
+
+This file is managed by [copier-uv-bleeding](https://github.com/detailobsessed/copier-uv-bleeding)
+and kept up to date on every `copier update`. Your project README lives in `README.md`.
+
+## Badges
+
+Copy these into your `README.md` to show project status on GitHub:
+
+```markdown
+[![ci](https://github.com/detailobsessed/codereviewbuddy/workflows/ci/badge.svg)](https://github.com/detailobsessed/codereviewbuddy/actions?query=workflow%3Aci)
+[![release](https://github.com/detailobsessed/codereviewbuddy/workflows/release/badge.svg)](https://github.com/detailobsessed/codereviewbuddy/actions?query=workflow%3Arelease)
+[![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://detailobsessed.github.io/codereviewbuddy/)
+[![pypi version](https://img.shields.io/pypi/v/codereviewbuddy.svg)](https://pypi.org/project/codereviewbuddy/)
+[![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
+[![codecov](https://codecov.io/gh/detailobsessed/codereviewbuddy/branch/main/graph/badge.svg)](https://codecov.io/gh/detailobsessed/codereviewbuddy)
+```
+
+## Installation
+
+```bash
+pip install codereviewbuddy
+```
+
+With [`uv`](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install codereviewbuddy
+```
+
+## Template Updates
+
+This project was generated with [copier-uv-bleeding](https://github.com/detailobsessed/copier-uv-bleeding).
+
+To pull the latest template changes (smart 3-way merge that respects your project changes):
+
+```bash
+copier update --trust .
+```
+
+To re-apply the template from scratch (ignores your project diff):
+
+```bash
+copier recopy --trust --overwrite .
+```

--- a/prek.toml
+++ b/prek.toml
@@ -40,7 +40,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.10.0"  # prek autoupdate will fill this
+rev = "0.10.2"  # prek autoupdate will fill this
 hooks = [{ id = "uv-lock", priority = 1 }]
 
 [[repos]]
@@ -55,7 +55,7 @@ hooks = [{ id = "actionlint", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = "v1.43.3"  # prek autoupdate will fill this
+rev = "v1.43.4"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]
@@ -65,7 +65,7 @@ hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.22.0"  # pinned: 'nightly' tag is mutable, update manually
+rev = "nightly"  # lychee tags nightly as latest; prek autoupdate may switch to it
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
@@ -91,9 +91,19 @@ pass_filenames = false
 priority = 1
 
 [[repos.hooks]]
+id = "pytest-testmon"
+name = "pytest affected tests"
+entry = "uv run pytest --testmon --no-cov"
+language = "system"
+types = ["python"]
+pass_filenames = false
+stages = ["pre-commit"]
+priority = 1
+
+[[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
-entry = "uv run pytest --cov=src/codereviewbuddy --cov-fail-under=90 --cov-report=term-missing:skip-covered -q"
+entry = "uv run pytest --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
 language = "system"
 types = ["python"]
 pass_filenames = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ ci = [
 ]
 local = [
     "prek>=0.3.1",
+    "pytest-testmon>=2.2",
 ]
 docs = [
     "markdown-callouts>=0.4",
@@ -159,7 +160,7 @@ filterwarnings = [
 [tool.coverage.run]
 branch = true
 parallel = true
-source = ["src/", "tests/"]
+source = ["src/"]
 
 [tool.coverage.report]
 precision = 2
@@ -182,6 +183,9 @@ lint = "ruff check ."
 format = "ruff format ."
 typecheck = "ty check ."
 
+# Testing
+test-affected = "pytest --testmon --no-cov"
+
 # Combined tasks
 check.parallel = ["lint", "typecheck"]
 check.ignore_fail = "return_non_zero"
@@ -200,7 +204,7 @@ verify-scaffold = "bash scripts/verify-scaffold.sh"
 
 # Template utilities
 check-template = "bash scripts/check-template-update.sh"
-update-template = "copier update --trust . --skip-answered"
+update-template = { shell = "copier update --trust . --skip-answered && prek autoupdate && echo '  ✓ Hook versions updated'" }
 
 # GitHub utilities
 # actions-up: https://github.com/azat-io/actions-up

--- a/scripts/check-template-update.sh
+++ b/scripts/check-template-update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Check if a newer version of the copier template is available.
 # Runs as a post-checkout hook — informational only, never blocks.
-# Set COPIER_CHECK_INTERVAL=900 in .envrc for 15-min checks (default: 86400 = 24h).
+# Override COPIER_CHECK_INTERVAL in .envrc (default: 900 = 15 min, script fallback: 86400 = 24h).
 set -euo pipefail
 
 # Skip file-level restores (arg 3 = 0); runs on branch switch, pull, rebase, clone

--- a/scripts/verify-scaffold.sh
+++ b/scripts/verify-scaffold.sh
@@ -20,7 +20,7 @@ section "Project Structure"
 # ---------------------------------------------------------------------------
 
 # Core files
-for f in pyproject.toml README.md LICENSE CHANGELOG.md CONTRIBUTING.md \
+for f in pyproject.toml README.md README_TEMPLATE.md LICENSE CHANGELOG.md CONTRIBUTING.md \
          CODE_OF_CONDUCT.md SECURITY.md .gitignore .envrc .env.example \
          .copier-answers.yml prek.toml .editorconfig \
          .markdownlint.yaml .lychee.toml mkdocs.yml; do
@@ -77,6 +77,21 @@ if grep -q 'detect-private-key' prek.toml; then
 else
     fail "detect-private-key hook missing"
 fi
+
+# Drift check: env vars used by template scripts must be documented
+# shellcheck disable=SC2043  # single-item loop — ready for more vars
+for var in COPIER_CHECK_INTERVAL; do
+    if grep -q "$var" .envrc 2>/dev/null; then
+        pass "$var documented in .envrc"
+    else
+        fail "$var used by template scripts but not documented in .envrc"
+    fi
+    if grep -q "$var" .env.example 2>/dev/null; then
+        pass "$var documented in .env.example"
+    else
+        fail "$var used by template scripts but not documented in .env.example"
+    fi
+done
 
 if grep -q 'gitleaks' prek.toml; then
     pass "gitleaks hook present"
@@ -227,6 +242,13 @@ else
     warn "CI: no CI workflow found"
 fi
 
+prd=".github/workflows/pr-description.yml"
+if [ -f "$prd" ]; then
+    pass "PR description check workflow present"
+elif [ -d ".github" ]; then
+    warn "PR description check workflow missing"
+fi
+
 rel=".github/workflows/release.yml"
 if [ -f "$rel" ]; then
     if grep -q 'semantic-release' "$rel"; then
@@ -255,7 +277,7 @@ if grep -q 'git-revision-date' mkdocs.yml; then pass "Git revision date plugin";
 section "Poe Tasks"
 # ---------------------------------------------------------------------------
 
-for task in setup lint format typecheck test test-all test-cov check fix \
+for task in setup lint format typecheck test test-affected test-all test-cov check fix \
             docs docs-build prek check-template update-template; do
     if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "^$task\." pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
         pass "Poe task: $task"
@@ -271,13 +293,13 @@ section "README Quality"
 if grep -q '\[!\[ci\]' README.md; then pass "CI badge present"; else warn "CI badge missing"; fi
 if grep -q '\[!\[release\]' README.md; then pass "Release badge present"; else warn "Release badge missing"; fi
 if grep -q '\[!\[documentation\]' README.md; then pass "Docs badge present"; else warn "Docs badge missing"; fi
-if grep -qi 'codecov\|coveralls\|coverage.*badge\|coverage.*img' README.md; then pass "Coverage badge present"; else fail "Coverage badge missing in README"; fi
+if grep -qi 'codecov\|coveralls\|coverage.*badge\|coverage.*img' README.md; then pass "Coverage badge present"; else warn "Coverage badge missing"; fi
 
 # Check for the known README formatting bug (#83)
-if grep -q '```##' README.md; then
-    fail "README: code fence merged with heading (no blank line) — copier-uv-bleeding#83"
+if grep -q '```##' README_TEMPLATE.md; then
+    fail "README_TEMPLATE: code fence merged with heading (no blank line) — copier-uv-bleeding#83"
 else
-    pass "README: no code fence / heading collision"
+    pass "README_TEMPLATE: no code fence / heading collision"
 fi
 
 # ---------------------------------------------------------------------------
@@ -301,7 +323,7 @@ section "Markdown Lint"
 # ---------------------------------------------------------------------------
 
 if command -v markdownlint &>/dev/null; then
-    md_errors=$(markdownlint README.md CONTRIBUTING.md CHANGELOG.md 2>&1 || true)
+    md_errors=$(markdownlint README.md README_TEMPLATE.md CONTRIBUTING.md CHANGELOG.md 2>&1 || true)
     if [[ -z "$md_errors" ]]; then
         pass "Core .md files pass markdownlint"
     else

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,7 +140,7 @@ class TestConfig:
 
     def test_diagnostics_from_toml(self, tmp_path: Path):
         toml_file = tmp_path / ".codereviewbuddy.toml"
-        toml_file.write_text("[diagnostics]\nio_tap = true\n")
+        toml_file.write_text("[diagnostics]\nio_tap = true\n", encoding="utf-8")
         config = load_config(cwd=tmp_path)
         assert config.diagnostics.io_tap is True
 

--- a/uv.lock
+++ b/uv.lock
@@ -238,6 +238,7 @@ docs = [
 ]
 local = [
     { name = "prek" },
+    { name = "pytest-testmon" },
 ]
 maintain = [
     { name = "build" },
@@ -274,7 +275,10 @@ docs = [
     { name = "mkdocs-section-index", specifier = ">=0.3.9" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },
 ]
-local = [{ name = "prek", specifier = ">=0.3.1" }]
+local = [
+    { name = "prek", specifier = ">=0.3.1" },
+    { name = "pytest-testmon", specifier = ">=2.2" },
+]
 maintain = [
     { name = "build", specifier = ">=1.2" },
     { name = "python-semantic-release", specifier = ">=10" },
@@ -389,7 +393,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8
 
 [[package]]
 name = "cyclopts"
-version = "4.5.1"
+version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -397,9 +401,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/93/6085aa89c3fff78a5180987354538d72e43b0db27e66a959302d0c07821a/cyclopts-4.5.1.tar.gz", hash = "sha256:fadc45304763fd9f5d6033727f176898d17a1778e194436964661a005078a3dd", size = 162075, upload-time = "2026-01-25T15:23:54.07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/cd/1fd03921a95113182e6fdf84af5d47f07aa91c00c03ac074c192b0d4672c/cyclopts-4.5.2.tar.gz", hash = "sha256:7fe01b2d184c55c4555e06a0397602b319d87faa5b086b41913eaeaea52fae16", size = 162381, upload-time = "2026-02-11T16:30:46.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/7c/996760c30f1302704af57c66ff2d723f7d656d0d0b93563b5528a51484bb/cyclopts-4.5.1-py3-none-any.whl", hash = "sha256:0642c93601e554ca6b7b9abd81093847ea4448b2616280f2a0952416574e8c7a", size = 199807, upload-time = "2026-01-25T15:23:55.219Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/03/f906829bcfcbb945f19d6a64240ffb66a31d69ca5533e95882f0efc9c13c/cyclopts-4.5.2-py3-none-any.whl", hash = "sha256:ee56ee23c2c81abc34b66b5aa8fd2698ca699740054e84e534449ec3eb7f944d", size = 200165, upload-time = "2026-02-11T16:30:46.942Z" },
 ]
 
 [[package]]
@@ -1526,6 +1530,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/3e/a4a9227807b56869790aad3e24472a554b585974fe7e551ea350f50897ae/pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7", size = 8304, upload-time = "2025-09-12T15:22:58.946Z" },
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Update copier-uv-bleeding template from **0.22.1 → 0.26.3** (14 files, 175 insertions).

This is the first real-world test of the improved template update workflow from PRs #197 and #198 in the template repo. Merge conflicts in `.envrc` and `pyproject.toml` were resolved manually, preserving project-specific customizations.

## What changed

### From template (auto-merged)
- **PR description workflow** — new `.github/workflows/pr-description.yml` validates PR bodies aren't empty/boilerplate
- **README_TEMPLATE.md** — template-managed doc with badges and install instructions (separate from project README)
- **pytest-testmon hook** — `poe test-affected` task + prek hook for running only tests affected by changes
- **release.yml fix** — checkout ref changed from `version` → `tag` (bug fix)
- **issue-triage.yml** — creates `needs-triage` label if it doesn't exist before adding it
- **verify-scaffold.sh** — expanded validation checks
- **check-template-update.sh** — updated default interval comment
- **Hook bumps** — uv-pre-commit 0.10.2, typos v1.43.4, lychee → nightly

### Merge conflict resolutions
- **`.envrc`** — kept existing virtualenv setup, accepted template's `COPIER_CHECK_INTERVAL` export and `dotenv_if_exists` hint
- **`pyproject.toml`** — kept `--cov` in addopts + `asyncio_mode = "auto"`, added `test-affected` task (dropped template's duplicate inline test/test-all/test-cov since we have table-style versions)

### Bug fixes found during update
- **`test_diagnostics_from_toml`** — added `encoding="utf-8"` to `write_text()` call (Python 3.14 `EncodingWarning` turned into error by `filterwarnings = ["error"]`)
- **testmon + pytest-cov conflict** — added `--no-cov` to testmon hook entry (testmon doesn't support branch coverage with pytest-cov)

## Checklist

- [x] Merge conflicts resolved preserving project customizations
- [x] All prek hooks pass locally
- [x] Commit messages follow conventional commits

## Related Issues

- Template PRs: detailobsessed/copier-uv-bleeding#197, detailobsessed/copier-uv-bleeding#198
- Discovered issues filed upstream: detailobsessed/copier-uv-bleeding#199, detailobsessed/copier-uv-bleeding#201