### PR TITLE
chore: update to latest uv-copier-bleeding template version

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.27.9
+_commit: 0.27.11
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic

--- a/prek.toml
+++ b/prek.toml
@@ -32,7 +32,7 @@ hooks = [{ id = "gitleaks", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.0"  # prek autoupdate will fill this
+rev = "v0.15.1"  # prek autoupdate will fill this
 hooks = [
   { id = "ruff", args = ["--fix"], priority = 1 },
   { id = "ruff-format", priority = 1 },
@@ -144,6 +144,7 @@ entry = "bash scripts/check-template-update.sh"
 language = "system"
 always_run = true
 pass_filenames = false
+verbose = true
 stages = ["post-checkout"]
 
 [[repos]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,13 @@ select = [
     "I",    # isort - import sorting
 
     # Code quality
+    "A",    # flake8-builtins - prevent shadowing builtins (id, type, list, etc.)
     "B",    # flake8-bugbear - common bugs and design issues
     "SIM",  # flake8-simplify - simplify code
     "C4",   # flake8-comprehensions - better comprehensions
     "PIE",  # flake8-pie - misc improvements
     "RET",  # flake8-return - return statement issues
+    "RSE",  # flake8-raise - raise best practices
     "RUF",  # Ruff-specific rules
     "FA",   # flake8-future-annotations
     "ISC",  # flake8-implicit-str-concat - catch missing commas
@@ -107,6 +109,22 @@ select = [
     "TC",   # flake8-type-checking - TYPE_CHECKING imports
     "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
     "FURB", # refurb - modernize and simplify code
+    "FLY",  # flynt - prefer f-strings over .format() and %
+
+    # Naming
+    # "N",  # pep8-naming - PEP 8 naming conventions (enable when ready)
+
+    # Datetime
+    "DTZ",  # flake8-datetimez - enforce timezone-aware datetimes
+
+    # Error messages
+    "EM",   # flake8-errmsg - no string literals in exceptions
+
+    # Pylint
+    "PLC",  # pylint conventions
+    "PLE",  # pylint errors
+    "PLR",  # pylint refactor (too-many-args, too-many-branches, etc.)
+    "PLW",  # pylint warnings
 
     # Performance
     "PERF", # Perflint - performance anti-patterns
@@ -127,13 +145,23 @@ select = [
 
     # Print statements (use logging instead)
     "T20",  # flake8-print
-
-    # Encoding
-    "PLW1514",  # unspecified-encoding - require encoding in open()
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "S603", "S607", "S701", "T201"]  # Allow assert, subprocess, jinja2, print in tests
+"tests/**" = [
+    "S101", "S603", "S607", "S701",  # Allow assert, subprocess, jinja2 in tests
+    "T201",       # Allow print in tests
+    "PLR6301",    # Test methods don't use self (pytest classes)
+    "PLR2004",    # Magic values in assertions are fine
+    "PLC0415",    # Lazy imports in test functions are idiomatic
+    "PLC2701",    # Private name imports for testing internals
+    "ARG002",     # Unused method arguments (fixtures)
+    "DTZ005",     # Naive datetime in tests is fine
+    "PLR0904",    # Test classes naturally have many test methods
+]
+
+[tool.ruff.lint.pylint]
+# All values are pylint defaults — do not inflate to hide violations.
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
@@ -173,6 +201,7 @@ output = "htmlcov/coverage.json"
 
 [tool.ty.environment]
 python-version = "3.14"
+python = ".venv"
 
 [tool.poe.tasks]
 # Setup


### PR DESCRIPTION
## Summary

Updates this repo to the latest `uv-copier-bleeding` template output.

## What changed

- Refreshed template-managed project files.
- Updated project/tooling config generated by template update workflow.
- Brought hook/tool versions in sync with current template defaults.

## Why

Keeps the repo aligned with upstream template improvements and avoids drift across generated projects.

## Validation

- `poe update-template`
- Pre-commit checks during stack submit

Related to template maintenance and CI/tooling hygiene.
