### PR TITLE
fix: add diagnostics log rotation and PEP 758 false-positive handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,39 @@ Add to `.cursor/mcp.json` in your project:
 }
 ```
 
+### Other major MCP clients (VS Code, Claude Code, Gemini CLI, ChatGPT, etc.)
+
+For clients not listed above, use the MCP install-instructions generator to get the exact config block and file path for your client version:
+
+- Hosted: <https://hyprmcp.com/mcp-install-instructions-generator/>
+- CLI:
+
+```bash
+npx @hyprmcp/mcp-install-instructions-generator@latest codereviewbuddy --output md
+```
+
+You can target a specific client explicitly, for example:
+
+```bash
+npx @hyprmcp/mcp-install-instructions-generator@latest codereviewbuddy --target vscode --output md
+npx @hyprmcp/mcp-install-instructions-generator@latest codereviewbuddy --target claude-code --output md
+npx @hyprmcp/mcp-install-instructions-generator@latest codereviewbuddy --target gemini-cli --output md
+npx @hyprmcp/mcp-install-instructions-generator@latest codereviewbuddy --target chatgpt --output md
+```
+
+Use the same runtime settings in every client:
+
+```json
+{
+  "mcpServers": {
+    "codereviewbuddy": {
+      "command": "uvx",
+      "args": ["--prerelease=allow", "codereviewbuddy@latest"]
+    }
+  }
+}
+```
+
 ### From source (development)
 
 ```json

--- a/docs/issue-65-observability.md
+++ b/docs/issue-65-observability.md
@@ -40,6 +40,10 @@ All started/completed/heartbeat entries include:
 
 - `tracking_tag: "CRB-ISSUE-65-TRACKING"`
 
+Rotation behavior:
+
+- `tool_calls.jsonl` truncates to the most recent 1000 lines every 100 writes.
+
 ### 2) Subprocess-level gh CLI timing (`gh_calls.jsonl`)
 
 File: `src/codereviewbuddy/gh.py`
@@ -57,6 +61,10 @@ Every `gh` CLI subprocess invocation is logged with:
 All entries include:
 
 - `tracking_tag: "CRB-ISSUE-65-TRACKING"`
+
+Rotation behavior:
+
+- `gh_calls.jsonl` truncates to the most recent 10,000 lines every 100 writes.
 
 ### Analysis query (jq)
 
@@ -77,6 +85,11 @@ Enhanced JSON-RPC metadata extraction:
 Added:
 
 - `tracking_tag: "CRB-ISSUE-65-TRACKING"` to all io tap rows.
+
+Rotation behavior:
+
+- On startup, `io_tap.jsonl` is truncated to the most recent 10,000 lines.
+- During runtime, it truncates to the most recent 10,000 lines every 100 writes.
 
 ### 4) Runtime diagnostics controls
 


### PR DESCRIPTION
## Description

This PR bundles three issue-driven improvements:

1. **Bound diagnostics log growth**
    - Added rotation/truncation for `gh_calls.jsonl` and `io_tap.jsonl` to prevent unbounded file growth.
    - Kept existing `tool_calls.jsonl` behavior and documented all rotation behavior.
2. **Downgrade known PEP 758 false positives**
    - Added centralized detection for AI-review comments that mislabel valid Python 3.14 `except` tuple syntax as Python 2 syntax.
    - These now classify as `info` instead of `bug`/`warning`.
3. **Improve MCP client install docs coverage**
    - Expanded README guidance for major MCP clients via the install-instructions generator workflow.

## What changed

- `src/codereviewbuddy/gh.py`
    - Added bounded rotation for `~/.codereviewbuddy/gh_calls.jsonl` (truncate to last 10,000 lines every 100 writes).
- `src/codereviewbuddy/io_tap.py`
    - Added bounded rotation for `~/.codereviewbuddy/io_tap.jsonl` (startup truncation + runtime truncation every 100 writes).
- `src/codereviewbuddy/tools/stack.py`
    - Added `_is_pep758_except_false_positive(...)` and integrated it into `_classify_severity(...)` to downgrade known false positives to `info`.
- `README.md`
    - Added “Other major MCP clients” section with generator-based installation instructions.
- `docs/issue-65-observability.md`
    - Documented log-rotation behavior for diagnostics logs.
- Tests
    - Added/updated regression coverage in:
        - `tests/test_gh.py`
        - `tests/test_io_tap.py`
        - `tests/test_stack.py`

## Validation

- `ruff check` on changed files: passed
- `poe test -o addopts='' tests/test_gh.py tests/test_io_tap.py tests/test_stack.py tests/test_triage.py tests/test_write_middleware.py`: **160 passed**

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] Commit messages follow conventional commits
- [x] `poe check` passes

## Related Issues

- Completed work for #125, #136, and #19
- Verified and closed #137 as already implemented

<!-- devin-review-badge-begin -->

---

<picture></picture><!-- devin-review-badge-end -->