### PR TITLE
fix: config typo detection, unified GraphQL errors, lighter triage queries

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -345,6 +345,21 @@ class TestCollectUnknownKeys:
         assert "pr_descriptions.require_review" in unknown
         assert "foo" in unknown
 
+    def test_unknown_key_within_known_reviewer(self):
+        """Typos like [reviewers.devin] bogus_key = true should be flagged."""
+        data = {"reviewers": {"devin": {"enabled": True, "bogus_key": True}}}
+        assert _collect_unknown_keys(data, Config) == ["reviewers.devin.bogus_key"]
+
+    def test_unknown_key_within_unknown_reviewer(self):
+        """Even unknown reviewer names should have their fields validated."""
+        data = {"reviewers": {"future_bot": {"enabled": True, "typo_field": 42}}}
+        assert _collect_unknown_keys(data, Config) == ["reviewers.future_bot.typo_field"]
+
+    def test_valid_keys_within_reviewer_not_flagged(self):
+        """All valid ReviewerConfig fields should pass without warnings."""
+        data = {"reviewers": {"devin": {"enabled": True, "auto_resolve_stale": False, "resolve_levels": ["info"]}}}
+        assert _collect_unknown_keys(data, Config) == []
+
 
 class TestLoadConfigWarnings:
     def test_warns_on_unknown_keys(self, tmp_path: Path, caplog: pytest.LogCaptureFixture):

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-from codereviewbuddy.models import CommentStatus, ReviewComment, ReviewSummary, ReviewThread
+from codereviewbuddy.models import CommentStatus, ReviewComment, ReviewThread
 from codereviewbuddy.tools.comments import (
     _classify_action,
     _extract_title,
@@ -174,9 +174,9 @@ class TestTriageReviewComments:
 
     def _mock_list(self, mocker: MockerFixture, threads: list[ReviewThread]) -> AsyncMock:
         return mocker.patch(
-            "codereviewbuddy.tools.comments.list_review_comments",
+            "codereviewbuddy.tools.comments._collect_inline_threads_only",
             new_callable=AsyncMock,
-            return_value=ReviewSummary(threads=threads),
+            return_value=threads,
         )
 
     async def test_unreplied_bug_needs_fix(self, mocker: MockerFixture):
@@ -266,11 +266,11 @@ class TestTriageReviewComments:
         info_43 = _thread(thread_id="PRRT_43", pr_number=43, body="📝 **Info: Issue B**")
 
         mock = mocker.patch(
-            "codereviewbuddy.tools.comments.list_review_comments",
+            "codereviewbuddy.tools.comments._collect_inline_threads_only",
             new_callable=AsyncMock,
             side_effect=[
-                ReviewSummary(threads=[bug_42]),
-                ReviewSummary(threads=[info_43]),
+                [bug_42],
+                [info_43],
             ],
         )
 


### PR DESCRIPTION
## Summary

Three small improvements addressing agent-reported issues:

### Config validation: detect typos in reviewer sub-sections (Fixes #91)

`_collect_unknown_keys` now recurses into `dict[str, ReviewerConfig]` sub-sections using `typing.get_args()`. Typos like `[reviewers.devin] bogus_key = true` are now flagged, while unknown reviewer *names* remain allowed (forward-compat).

### Unified GraphQL mutation error handling (Fixes #92)

Added `_check_graphql_errors` helper that checks `result.get('errors')` consistently across all three mutation paths:
- `resolve_comment` — now checks errors before verifying success data
- `resolve_stale_comments` batch — was fire-and-forget, now checks errors
- `_reply_to_review_thread` — refactored to use shared helper

### Lighter triage queries (Fixes #107)

`triage_review_comments` now uses `_collect_inline_threads_only` which skips commit fetch, compare API (staleness), PR-level reviews, bot comments, and stack discovery. For a stack of N PRs this saves ~4N API calls.