### PR TITLE
feat: add MCP prompts for review_stack, pr_review_checklist, and ship_stack

### DIFF
--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -131,6 +131,43 @@ class TestToolRegistration:
         tools = await client.list_tools()
         assert len(tools) == 11
 
+
+class TestPromptRegistration:
+    EXPECTED_PROMPTS = frozenset({
+        "review_stack",
+        "pr_review_checklist",
+        "ship_stack",
+    })
+
+    async def test_all_prompts_registered(self, client: Client):
+        prompts = await client.list_prompts()
+        names = {p.name for p in prompts}
+        assert names == self.EXPECTED_PROMPTS
+
+    async def test_prompt_count(self, client: Client):
+        prompts = await client.list_prompts()
+        assert len(prompts) == 3
+
+    async def test_review_stack_returns_content(self, client: Client):
+        from mcp.types import TextContent
+
+        result = await client.get_prompt("review_stack")
+        assert len(result.messages) >= 1
+        content = result.messages[0].content
+        assert isinstance(content, TextContent)
+        assert "summarize_review_status" in content.text
+        assert "triage_review_comments" in content.text
+
+    async def test_ship_stack_mentions_activity(self, client: Client):
+        from mcp.types import TextContent
+
+        result = await client.get_prompt("ship_stack")
+        content = result.messages[0].content
+        assert isinstance(content, TextContent)
+        assert "stack_activity" in content.text
+
+
+class TestToolSchemas:
     async def test_list_review_comments_schema(self, client: Client):
         tools = await client.list_tools()
         tool = next(t for t in tools if t.name == "list_review_comments")


### PR DESCRIPTION
## Summary

Fixes #114

Adds three MCP prompts (user-invoked slash commands) for common review workflows:

### `review_stack`
Full review pass workflow — structured steps from status summary through triage, fixes, replies, issue creation, stale resolution, re-review, and description verification.

### `pr_review_checklist`
Pre-merge checklist covering code quality, PR hygiene, review cycle completion, and testing. Agents can use this to verify nothing was missed.

### `ship_stack`
Pre-merge sanity check — verifies no unresolved bugs, checks activity timeline for settled state, validates PR descriptions have issue links.

### Why prompts (not instructions)?
These are user-triggered workflows, not always-on behaviors. Prompts are ideal because the user explicitly invokes them (e.g. `/mcp.codereviewbuddy.review_stack`) when they want a structured workflow, rather than having the agent do it automatically.