### PR TITLE
feat: hot-reload config on every tool call (closes #70)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit configuration — only non-default values shown.
+# Full schema: https://coderabbit.ai/integrations/schema.v2.json
+early_access: true
+reviews:
+  request_changes_workflow: true
+  review_details: true
+  fail_commit_status: true
+  auto_apply_labels: true
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  auto_review:
+    auto_pause_after_reviewed_commits: 0
+issue_enrichment:
+  auto_enrich:
+    enabled: true

--- a/.codereviewbuddy.toml
+++ b/.codereviewbuddy.toml
@@ -9,7 +9,7 @@
 #   info     — 📝 informational, no action required
 
 [reviewers.devin]
-enabled = true                  # Set to false to ignore Devin comments entirely
+enabled = true                  # Re-enabled to handle existing threads; disable after backlog cleared
 auto_resolve_stale = false      # Devin auto-resolves its own bug threads; we skip them
 resolve_levels = ["info", "warning", "flagged"]  # Resolve threads we've addressed; bugs stay for Devin to auto-resolve
 
@@ -19,12 +19,12 @@ resolve_levels = ["info", "warning", "flagged"]  # Resolve threads we've address
 # resolve_levels = ["info", "warning", "flagged", "bug"]  # All levels allowed
 
 [reviewers.coderabbit]
-# enabled = true
-# auto_resolve_stale = false      # CodeRabbit handles its own resolution
-# resolve_levels = []             # Don't resolve any CodeRabbit threads
+enabled = true                  # CodeRabbit Pro trial — active on all public repos
+auto_resolve_stale = false      # CodeRabbit handles its own resolution
+resolve_levels = []             # Don't resolve any CodeRabbit threads (it manages its own)
 
 [pr_descriptions]
-enabled = true                  # Set to false to disable PR description tools entirely
+enabled = false                  # Set to false to disable PR description tools entirely
 
 [self_improvement]
 enabled = true                 # Set to true to instruct agents to file issues for server gaps

--- a/src/codereviewbuddy/io_tap.py
+++ b/src/codereviewbuddy/io_tap.py
@@ -257,9 +257,11 @@ def _should_enable_io_tap() -> bool:
     try:
         from codereviewbuddy.config import load_config  # noqa: PLC0415
 
-        return load_config().diagnostics.io_tap
+        config, _path = load_config()
     except Exception:
         return False
+    else:
+        return config.diagnostics.io_tap
 
 
 def install_io_tap() -> bool:

--- a/tests/test_io_tap.py
+++ b/tests/test_io_tap.py
@@ -395,7 +395,7 @@ class TestShouldEnableIoTap:
         from codereviewbuddy.config import Config, DiagnosticsConfig
 
         mock_config = Config(diagnostics=DiagnosticsConfig(io_tap=True))
-        mocker.patch("codereviewbuddy.config.load_config", return_value=mock_config)
+        mocker.patch("codereviewbuddy.config.load_config", return_value=(mock_config, None))
         assert _should_enable_io_tap() is False
 
     def test_config_enables_when_no_env_var(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
@@ -403,7 +403,7 @@ class TestShouldEnableIoTap:
         from codereviewbuddy.config import Config, DiagnosticsConfig
 
         mock_config = Config(diagnostics=DiagnosticsConfig(io_tap=True))
-        mocker.patch("codereviewbuddy.config.load_config", return_value=mock_config)
+        mocker.patch("codereviewbuddy.config.load_config", return_value=(mock_config, None))
         assert _should_enable_io_tap() is True
 
     def test_defaults_false_when_no_env_and_no_config(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):


### PR DESCRIPTION
## Summary

Fixes #70

Config changes in `.codereviewbuddy.toml` now take effect on the next tool call without restarting the MCP server. Previously, config was loaded once at startup in the lifespan handler.

### How it works

- `get_config()` checks the config file's `mtime` on each call (~microseconds overhead)
- If mtime changed: re-reads, re-validates, re-applies to reviewer adapters and middleware
- Reload callbacks notify `server.py` to re-apply adapter config and diagnostics settings
- `load_config()` now returns `(Config, Path | None)` so the path is available for mtime tracking

### Edge cases handled

- **Deleted file** → falls back to defaults gracefully
- **Invalid TOML after edit** → logs warning, keeps last good config
- **No config file at startup** → skips hot-reload entirely (no mtime to check)
- **Failing reload callback** → logged, doesn't block config update

### Also included

- `.coderabbit.yaml` — CodeRabbit Pro configuration (now active on public repos)
- `.codereviewbuddy.toml` — re-enabled Devin to handle existing review threads

### Tests

7 new tests in `TestHotReload` covering all acceptance criteria:
- Cached when unchanged, detects file change, deleted file fallback, invalid edit keeps last good, reload callbacks fire, callback errors don't break reload, no-path skips hot-reload