### PR TITLE
refactor: remove unreliable reviews_in_progress heuristic (#151)

### DIFF
--- a/.codereviewbuddy.toml
+++ b/.codereviewbuddy.toml
@@ -9,9 +9,9 @@
 #   info     — 📝 informational, no action required
 
 [reviewers.devin]
-enabled = true                  # Re-enabled to handle existing threads; disable after backlog cleared
-auto_resolve_stale = false      # Devin auto-resolves its own bug threads; we skip them
-resolve_levels = ["info", "warning", "flagged"]  # Resolve threads we've addressed; bugs stay for Devin to auto-resolve
+enabled = false                 # Devin removed from this repository
+auto_resolve_stale = false
+resolve_levels = ["info", "warning", "flagged"]
 
 [reviewers.unblocked]
 # enabled = true

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -61,9 +61,6 @@ class ReviewSummary(BaseModel):
 
     threads: list[ReviewThread] = Field(default_factory=list, description="All review threads on the PR")
     reviewer_statuses: list[ReviewerStatus] = Field(default_factory=list, description="Per-reviewer status based on timestamp heuristic")
-    reviews_in_progress: bool = Field(
-        default=False, description="True if at least one reviewer has a pending review (pushed after last review)"
-    )
     stack: list[StackPR] = Field(default_factory=list, description="Other PRs in the same stack, discovered via branch chain")
     error: str | None = Field(default=None, description="Error message if the request failed")
 
@@ -81,7 +78,6 @@ class PRReviewStatusSummary(BaseModel):
     warnings: int = Field(default=0, description="Number of 🟡 warning threads")
     info_count: int = Field(default=0, description="Number of 📝 info threads")
     stale: int = Field(default=0, description="Number of unresolved stale threads (file changed after comment)")
-    reviews_in_progress: bool = Field(default=False, description="Whether any reviewer hasn't reviewed the latest push")
 
 
 class StackReviewStatusResult(BaseModel):
@@ -89,7 +85,6 @@ class StackReviewStatusResult(BaseModel):
 
     prs: list[PRReviewStatusSummary] = Field(default_factory=list, description="Per-PR review status, bottom to top")
     total_unresolved: int = Field(default=0, description="Total unresolved threads across the stack")
-    any_reviews_in_progress: bool = Field(default=False, description="Whether any PR has pending reviews")
     error: str | None = Field(default=None, description="Error message if the request failed")
 
 

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -234,13 +234,6 @@ class TestListReviewComments:
         assert "unblocked" in reviewer_names
         assert "devin" in reviewer_names
 
-    async def test_reviews_in_progress_when_pushed_after_review(self):
-        """Commit at 12:00, reviews at 10:00/11:00 → both pending."""
-        summary = await list_review_comments(42)
-        assert summary.reviews_in_progress is True
-        for s in summary.reviewer_statuses:
-            assert s.status == "pending"
-
     async def test_disabled_reviewer_threads_filtered(self, mocker: MockerFixture):
         """Threads from disabled reviewers should not appear in results."""
         from codereviewbuddy.config import Config, ReviewerConfig

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -283,6 +283,9 @@ class TestResolveCommentMCP:
         assert "Error resolving PRRT_test" in result.content[0].text  # type: ignore[unresolved-attribute]
 
     async def test_blocked_by_config(self, client: Client, mocker: MockerFixture):
+        from codereviewbuddy.config import Config, set_config
+
+        set_config(Config())  # defaults: devin enabled, bugs not in resolve_levels
         mocker.patch(
             "codereviewbuddy.tools.comments._fetch_thread_detail",
             return_value=("devin", "🔴 **Bug: something is broken**"),


### PR DESCRIPTION
## Summary

Removes the unreliable `reviews_in_progress` heuristic that compared push timestamps vs review timestamps. Filed #151 to rethink this using GitHub's native reviewer API / CodeRabbit status.

### What was removed

- `reviews_in_progress` field from `ReviewSummary` and `PRReviewStatusSummary`
- `any_reviews_in_progress` field from `StackReviewStatusResult`
- `_build_mini_threads()` helper (dead code after removal)
- Commit fetching in `summarize_review_status` (was only needed for the timestamp heuristic)
- 2 tests that asserted the heuristic behavior
- ctx.warning about pending reviews

### What stays

- `reviewer_statuses` field on `ReviewSummary` — still useful for showing who reviewed and when
- `_build_reviewer_statuses()` — still called by `list_review_comments`

### Also fixed

- `test_blocked_by_config` now mocks config explicitly — was failing because hot-reload (PR #150) picked up the live config where Devin is disabled
- Disabled Devin in `.codereviewbuddy.toml` (removed from repo)

### Net effect

`summarize_review_status` no longer fetches commits per PR, making it faster (fewer API calls).