### PR TITLE
feat: expose show_config MCP tool (#108)

### DIFF
--- a/src/codereviewbuddy/config.py
+++ b/src/codereviewbuddy/config.py
@@ -389,6 +389,11 @@ def set_config(config: Config, *, config_path: Path | None = None) -> None:
         _state.mtime = None
 
 
+def get_config_path() -> Path | None:
+    """Return the path to the active config file, or None if using defaults."""
+    return _state.path
+
+
 def register_reload_callback(callback: Any) -> None:
     """Register a callable to invoke after config hot-reload.
 

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -183,3 +183,11 @@ class TriageResult(BaseModel):
     needs_issue: int = Field(default=0, description="Count of 'noted for followup' replies missing a GH issue reference")
     total: int = Field(default=0, description="Total actionable threads")
     error: str | None = Field(default=None, description="Error message if the request failed")
+
+
+class ConfigInfo(BaseModel):
+    """Active codereviewbuddy configuration with metadata."""
+
+    config: dict = Field(description="Full configuration as a dictionary")
+    config_path: str | None = Field(default=None, description="Path to the .codereviewbuddy.toml file, or null if using defaults")
+    hot_reload: bool = Field(default=False, description="Whether config changes are automatically picked up")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Global test fixtures for codereviewbuddy."""
+
+from __future__ import annotations
+
+import pytest
+
+from codereviewbuddy.config import Config, set_config
+
+
+@pytest.fixture(autouse=True)
+def _default_config():
+    """Reset config to defaults before every test.
+
+    The committed .codereviewbuddy.toml may disable reviewers (e.g. Devin),
+    which breaks tests that expect all reviewers enabled. This fixture
+    ensures every test starts with a clean default config.
+    """
+    set_config(Config())
+    yield
+    set_config(Config())


### PR DESCRIPTION
## Summary

Adds a  MCP tool so agents can programmatically inspect the active configuration without needing filesystem access. Closes #108.

### What's new

- **`show_config` tool** — returns the full config dict, config file path, and whether hot-reload is active
- **`ConfigInfo` model** in `models.py` — typed response for the tool
- **`get_config_path()`** public accessor in `config.py` — avoids exposing `_state` internals

### Also cleaned up

- Removed stale "Review status detection" section from server instructions (referenced removed `reviews_in_progress` heuristic)
- Updated server instructions: `show_config` replaces "check the config file" language in self-improvement section
- Updated prompt templates to remove `reviews_in_progress` references

### Tests

- `TestShowConfigMCP.test_returns_config` — verifies tool returns expected structure through MCP
- `TestShowConfigMCP.test_reflects_live_config` — verifies tool reads the live config, not a stale snapshot
- Tool registration tests updated (12 tools)

Closes #108