### PR TITLE
feat: block resolving threads without a reply (#110)

### DIFF
--- a/src/codereviewbuddy/config.py
+++ b/src/codereviewbuddy/config.py
@@ -64,6 +64,10 @@ class ReviewerConfig(BaseModel):
         default_factory=lambda: list(Severity),
         description="Severity levels that are allowed to be resolved",
     )
+    require_reply_before_resolve: bool = Field(
+        default=True,
+        description="Block resolve_comment unless the thread has a non-reviewer reply explaining how the feedback was addressed",
+    )
     rereview_message: str | None = Field(
         default=None,
         min_length=1,

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -271,7 +271,10 @@ class TestListReviewCommentsMCP:
 
 class TestResolveCommentMCP:
     async def test_success(self, client: Client, mocker: MockerFixture):
-        mocker.patch("codereviewbuddy.tools.comments._fetch_thread_detail", return_value=("unblocked", "some comment"))
+        mocker.patch(
+            "codereviewbuddy.tools.comments._fetch_thread_detail",
+            return_value=("unblocked", "some comment", ["unblocked-ai[bot]", "ichoosetoaccept"]),
+        )
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=RESOLVE_SUCCESS)
 
         result = await client.call_tool("resolve_comment", {"pr_number": 42, "thread_id": "PRRT_kwDOtest123"})
@@ -279,7 +282,10 @@ class TestResolveCommentMCP:
 
     async def test_failure_returns_error_string(self, client: Client, mocker: MockerFixture):
         fail_response = {"data": {"resolveReviewThread": {"thread": {"id": "PRRT_test", "isResolved": False}}}}
-        mocker.patch("codereviewbuddy.tools.comments._fetch_thread_detail", return_value=("unblocked", "some comment"))
+        mocker.patch(
+            "codereviewbuddy.tools.comments._fetch_thread_detail",
+            return_value=("unblocked", "some comment", ["unblocked-ai[bot]", "ichoosetoaccept"]),
+        )
         mocker.patch("codereviewbuddy.tools.comments.gh.graphql", return_value=fail_response)
 
         result = await client.call_tool("resolve_comment", {"pr_number": 42, "thread_id": "PRRT_test"})
@@ -289,7 +295,7 @@ class TestResolveCommentMCP:
     async def test_blocked_by_config(self, client: Client, mocker: MockerFixture):
         mocker.patch(
             "codereviewbuddy.tools.comments._fetch_thread_detail",
-            return_value=("devin", "🔴 **Bug: something is broken**"),
+            return_value=("devin", "🔴 **Bug: something is broken**", ["devin-ai-integration[bot]", "ichoosetoaccept"]),
         )
 
         result = await client.call_tool("resolve_comment", {"pr_number": 42, "thread_id": "PRRT_test"})


### PR DESCRIPTION
## Summary

Fixes #110 — agents can no longer silently resolve review threads without explaining how feedback was addressed.

## Changes

**Config** (`config.py`):
- Added `require_reply_before_resolve: bool = True` to `ReviewerConfig`
- Default ON — every resolved thread must have a non-reviewer reply first

**Thread detail query** (`comments.py`):
- Expanded `_THREAD_DETAIL_QUERY` from `first: 1` to `first: 50` to fetch all thread comments
- Updated `_fetch_thread_detail()` to return `(reviewer_name, comment_body, all_logins)` (3-tuple)
- Added `_has_non_reviewer_reply()` helper — checks if any reply author is NOT the reviewer bot

**Resolve enforcement** (`comments.py`):
- `resolve_comment()` now checks `require_reply_before_resolve` after the severity check
- If no non-reviewer reply exists, raises `GhError("Cannot resolve thread without a reply...")`
- `resolve_stale_comments()` is **not affected** — bulk stale resolution skips this check (different policy per issue #110)

**Config opt-out:**
```toml
[reviewers.unblocked]
require_reply_before_resolve = false
```

## Tests

3 new tests + 8 updated mocks:
- `test_blocked_without_reply` — blocks resolve when only reviewer comment exists
- `test_allowed_with_reply` — allows resolve when non-reviewer reply exists
- `test_reply_check_disabled_by_config` — config opt-out works

All 425 tests pass.

## Checklist

- [x] Tests added/updated
- [x] `poe check` passes
- [x] Commit messages follow conventional commits