### PR TITLE
feat!: env-var-first config, remove TOML config file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=3.0.0rc1",
-    "tomlkit>=0.13",
+    "pydantic-settings>=2.0",
 ]
 
 [project.scripts]

--- a/src/codereviewbuddy/config.py
+++ b/src/codereviewbuddy/config.py
@@ -1,22 +1,22 @@
 """Per-reviewer configuration system.
 
-Loads ``.codereviewbuddy.toml`` from the project root (walking up to ``.git``),
-validates with Pydantic, and provides sensible defaults so zero-config still works.
+All configuration is via ``CRB_*`` environment variables, set in MCP client config.
+Zero-config still works — all settings have sensible defaults.
+
+Uses ``pydantic-settings`` ``BaseSettings`` (same pattern as FastMCP's own settings)
+so env vars are read automatically with the ``CRB_`` prefix and ``__`` nesting.
 """
 
 from __future__ import annotations
 
 import logging
-import tomllib
 from enum import StrEnum
-from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
-
-CONFIG_FILENAME = ".codereviewbuddy.toml"
 
 
 class Severity(StrEnum):
@@ -189,457 +189,57 @@ class Config(BaseModel):
         return True, ""
 
 
-def _get_dict_value_model(annotation: Any) -> type[BaseModel] | None:
-    """Extract the value model from ``dict[str, SomeModel]`` type annotations.
+def load_config() -> Config:
+    """Load configuration from ``CRB_*`` environment variables.
 
-    Returns the model class if annotation is ``dict[str, <BaseModel subclass>]``,
-    otherwise ``None``.
+    Uses ``pydantic-settings`` so all fields are populated from env vars
+    automatically.  Zero-config still works — all fields have defaults.
+
+    Reviewer-specific env vars use ``__`` nesting, e.g.::
+
+        CRB_REVIEWERS__DEVIN__ENABLED = false
+        CRB_SELF_IMPROVEMENT__ENABLED = true
+        CRB_SELF_IMPROVEMENT__REPO = owner / repo
+        CRB_DIAGNOSTICS__IO_TAP = true
     """
-    import typing  # noqa: PLC0415
 
-    args = typing.get_args(annotation)
-    if len(args) == 2 and isinstance(args[1], type) and issubclass(args[1], BaseModel):  # noqa: PLR2004
-        return args[1]
-    return None
+    class _EnvConfig(BaseSettings):
+        """Thin wrapper that reads ``CRB_*`` env vars into a ``Config``."""
 
-
-def _collect_unknown_keys(
-    data: dict[str, Any],
-    model_cls: type[BaseModel],
-    prefix: str = "",
-) -> list[str]:
-    """Recursively find keys in *data* that don't match any field in *model_cls*.
-
-    Unknown reviewer *names* under ``[reviewers.*]`` are intentionally allowed
-    (forward-compat for new reviewers).  Only unknown *keys within* known
-    sections are flagged.
-
-    Returns dotted key paths like ``pr_descriptions.require_review``.
-    """
-    known = set(model_cls.model_fields)
-    unknown: list[str] = []
-
-    for key, value in data.items():
-        dotted = f"{prefix}{key}"
-        if key not in known:
-            unknown.append(dotted)
-            continue
-        field_info = model_cls.model_fields[key]
-        annotation = field_info.annotation
-        # Recurse into sub-models
-        if isinstance(annotation, type) and issubclass(annotation, BaseModel) and isinstance(value, dict):
-            unknown.extend(_collect_unknown_keys(value, annotation, prefix=f"{dotted}."))
-            continue
-        # Recurse into dict[str, SubModel] (e.g. reviewers: dict[str, ReviewerConfig]).
-        # Unknown dict *keys* are allowed (forward-compat for new reviewer names),
-        # but unknown fields *within* each value are flagged.
-        value_model = _get_dict_value_model(annotation)
-        if value_model is not None and isinstance(value, dict):
-            for sub_key, sub_value in value.items():
-                if isinstance(sub_value, dict):
-                    unknown.extend(_collect_unknown_keys(sub_value, value_model, prefix=f"{dotted}.{sub_key}."))
-
-    return unknown
-
-
-def _find_config_file(start: Path) -> Path | None:
-    """Walk up from *start* looking for ``.codereviewbuddy.toml``, stopping at ``.git`` root."""
-    current = start.resolve()
-    while True:
-        candidate = current / CONFIG_FILENAME
-        if candidate.is_file():
-            return candidate
-        # Stop at filesystem root
-        if current.parent == current:
-            return None
-        # Stop if we just checked a directory that contains .git
-        if (current / ".git").exists():
-            return None
-        current = current.parent
-
-
-def load_config(cwd: str | Path | None = None) -> tuple[Config, Path | None]:
-    """Load configuration from ``.codereviewbuddy.toml``.
-
-    Walks up from *cwd* (defaulting to the current directory) looking for the
-    config file.  If not found, returns a ``Config`` with all defaults.
-
-    Returns:
-        (config, config_path) — the parsed config and the file path (or None
-        if no config file was found).  The path is needed by ``set_config``
-        to enable mtime-based hot-reload.
-
-    Raises ``ValueError`` on invalid TOML or validation errors so the server
-    can refuse to start with a broken config.
-    """
-    start = Path(cwd) if cwd else Path.cwd()
-    config_path = _find_config_file(start)
-
-    if config_path is None:
-        logger.info("No %s found, using defaults", CONFIG_FILENAME)
-        return Config(), None
-
-    logger.info("Loading config from %s", config_path)
-    try:
-        raw = config_path.read_text(encoding="utf-8")
-        data = tomllib.loads(raw)
-    except tomllib.TOMLDecodeError as exc:
-        msg = f"Invalid TOML in {config_path}: {exc}"
-        raise ValueError(msg) from exc
-
-    try:
-        config = Config.model_validate(data)
-    except Exception as exc:
-        msg = f"Invalid config in {config_path}: {exc}"
-        raise ValueError(msg) from exc
-
-    unknown = _collect_unknown_keys(data, Config)
-    for key in unknown:
-        logger.warning(
-            "Unknown config key '%s' in %s — run 'codereviewbuddy config --update' to clean up",
-            key,
-            config_path,
+        model_config = SettingsConfigDict(
+            env_prefix="CRB_",
+            env_nested_delimiter="__",
+            extra="ignore",
         )
 
-    return config, config_path
+        reviewers: dict[str, ReviewerConfig] = Field(default_factory=dict)
+        pr_descriptions: PRDescriptionsConfig = Field(default_factory=PRDescriptionsConfig)
+        self_improvement: SelfImprovementConfig = Field(default_factory=SelfImprovementConfig)
+        diagnostics: DiagnosticsConfig = Field(default_factory=DiagnosticsConfig)
+
+    env = _EnvConfig()
+    # Build a proper Config (which applies reviewer defaults via model_validator)
+    config = Config(
+        reviewers=env.reviewers,
+        pr_descriptions=env.pr_descriptions,
+        self_improvement=env.self_improvement,
+        diagnostics=env.diagnostics,
+    )
+    logger.info("Config loaded from CRB_* env vars")
+    return config
 
 
-# -- Hot-reloading config with mtime cache ------------------------------------
+# -- Global config state (set once at startup) ---------------------------------
 
-
-class _ConfigState:
-    """Tracks the active config, its file path, and mtime for hot-reload."""
-
-    __slots__ = ("_on_reload", "config", "mtime", "path")
-
-    def __init__(self) -> None:
-        self.config: Config = Config()
-        self.path: Path | None = None
-        self.mtime: float | None = None
-        self._on_reload: list[_ReloadCallback] = []
-
-    def register_reload_callback(self, callback: _ReloadCallback) -> None:
-        """Register a callback to invoke after config hot-reload."""
-        self._on_reload.append(callback)
-
-    def _fire_reload_callbacks(self, config: Config) -> None:
-        for cb in self._on_reload:
-            try:
-                cb(config)
-            except Exception:
-                logger.exception("Config reload callback failed")
-
-
-_ReloadCallback = Any  # Callable[[Config], None] — avoid typing complexity
-
-_state = _ConfigState()
+_active_config: Config = Config()
 
 
 def get_config() -> Config:
-    """Return the active configuration, hot-reloading if the file changed.
-
-    Checks the config file's mtime on each call (~microseconds).  If the file
-    was modified, re-reads and re-validates it.  If deleted, falls back to
-    defaults.  If invalid, logs a warning and keeps the last good config.
-    """
-    path = _state.path
-    if path is None:
-        # No config file was found at startup — nothing to hot-reload
-        return _state.config
-
-    try:
-        current_mtime = path.stat().st_mtime
-    except OSError:
-        # File was deleted — fall back to defaults
-        if _state.mtime is not None:
-            logger.warning("%s deleted — falling back to defaults", path.name)
-            _state.config = Config()
-            _state.mtime = None
-            _state._fire_reload_callbacks(_state.config)
-        return _state.config
-
-    if current_mtime == _state.mtime:
-        return _state.config
-
-    # File changed — reload
-    logger.info("Config file changed (mtime %.0f → %.0f), reloading", _state.mtime or 0, current_mtime)
-    try:
-        raw = path.read_text(encoding="utf-8")
-        data = tomllib.loads(raw)
-        new_config = Config.model_validate(data)
-    except (tomllib.TOMLDecodeError, Exception) as exc:
-        logger.warning("Invalid config after edit — keeping last good config: %s", exc)
-        _state.mtime = current_mtime  # Don't re-check until next change
-        return _state.config
-
-    _state.config = new_config
-    _state.mtime = current_mtime
-    _state._fire_reload_callbacks(new_config)
-    logger.info("Config hot-reloaded successfully")
-    return new_config
+    """Return the active configuration (set at server startup via ``set_config``)."""
+    return _active_config
 
 
-def set_config(config: Config, *, config_path: Path | None = None) -> None:
-    """Set the active configuration (called during server startup).
-
-    If *config_path* is provided, enables hot-reload on subsequent
-    ``get_config()`` calls by tracking the file's mtime.
-    """
-    _state.config = config
-    _state.path = config_path
-    try:
-        _state.mtime = config_path.stat().st_mtime if config_path else None
-    except OSError:
-        _state.mtime = None
-
-
-def get_config_path() -> Path | None:
-    """Return the path to the active config file, or None if using defaults."""
-    return _state.path
-
-
-def register_reload_callback(callback: Any) -> None:
-    """Register a callable to invoke after config hot-reload.
-
-    The callback receives the new ``Config`` instance.  Used by ``server.py``
-    to re-apply adapter config and middleware diagnostics when the file changes.
-    """
-    _state.register_reload_callback(callback)
-
-
-# -- Template sections for ``codereviewbuddy config`` --------------------------
-
-# Each section is a (header_pattern, text_block) pair. The header_pattern is
-# used to check whether the section already exists in the user's config file.
-# The text_block is what gets written for --init or appended for --update.
-
-_TEMPLATE_HEADER = """\
-# .codereviewbuddy.toml — Per-reviewer configuration for codereviewbuddy
-# All settings are optional. Omitted values use sensible defaults.
-# Place this file in your project root (next to .git/).
-#
-# Severity levels used by resolve_levels:
-#   bug      — 🔴 critical issues, must fix before merge
-#   flagged  — 🚩 likely needs a code change
-#   warning  — 🟡 worth addressing but not blocking
-#   info     — 📝 informational, no action required
-"""
-
-_TEMPLATE_SECTIONS: list[tuple[str, str]] = [
-    (
-        "[reviewers.devin]",
-        """\
-[reviewers.devin]
-enabled = true                    # Set to false to ignore Devin comments entirely
-auto_resolve_stale = false        # Devin auto-resolves its own bug threads; we skip them
-resolve_levels = ["info"]         # Only allow resolving info-level threads from Devin
-""",
-    ),
-    (
-        "[reviewers.unblocked]",
-        """\
-[reviewers.unblocked]
-enabled = true
-auto_resolve_stale = true         # We batch-resolve Unblocked's stale threads
-resolve_levels = ["info", "warning", "flagged", "bug"]  # All levels allowed
-# rereview_message = "@unblocked please re-review"  # Message posted to trigger re-review
-""",
-    ),
-    (
-        "[reviewers.coderabbit]",
-        """\
-[reviewers.coderabbit]
-enabled = true
-auto_resolve_stale = false        # CodeRabbit handles its own resolution
-resolve_levels = []               # Don't resolve any CodeRabbit threads
-""",
-    ),
-    (
-        "[pr_descriptions]",
-        """\
-[pr_descriptions]
-enabled = true                    # Set to false to disable PR description review tool
-""",
-    ),
-    (
-        "[self_improvement]",
-        """\
-[self_improvement]
-enabled = true                    # Agents file issues when they encounter server gaps
-repo = "detailobsessed/codereviewbuddy"  # Repository to file issues against
-""",
-    ),
-    (
-        "[diagnostics]",
-        """\
-[diagnostics]
-io_tap = true                     # Log stdin/stdout for transport debugging (#65)
-tool_call_heartbeat = false       # Emit heartbeat entries for long-running tool calls
-heartbeat_interval_ms = 5000      # Heartbeat cadence when enabled
-include_args_fingerprint = true   # Log args hash/size (no raw args)
-""",
-    ),
-]
-
-DEFAULT_CONFIG_TEMPLATE = _TEMPLATE_HEADER + "\n".join(block for _, block in _TEMPLATE_SECTIONS)
-
-
-def init_config(cwd: Path | None = None) -> Path:
-    """Create a new ``.codereviewbuddy.toml`` in the given directory.
-
-    Raises ``SystemExit(1)`` if the file already exists.
-
-    Returns:
-        Path to the created file.
-    """
-    target = (cwd or Path.cwd()) / CONFIG_FILENAME
-    if target.exists():
-        print(f"Error: {CONFIG_FILENAME} already exists in {target.parent}")  # noqa: T201
-        print("Hint: use 'codereviewbuddy config --update' to add new sections")  # noqa: T201
-        raise SystemExit(1)
-    target.write_text(DEFAULT_CONFIG_TEMPLATE, encoding="utf-8")
-    print(f"Created {target}")  # noqa: T201
-    return target
-
-
-def _comment_out_unknown_keys(target: Path) -> list[str]:
-    """Comment out unknown keys in a config file using tomlkit (style-preserving).
-
-    Returns list of dotted key paths that were commented out.
-    """
-    import tomlkit  # noqa: PLC0415
-
-    raw = target.read_text(encoding="utf-8")
-    data = tomllib.loads(raw)
-    unknown = _collect_unknown_keys(data, Config)
-    if not unknown:
-        return []
-
-    doc = tomlkit.loads(raw)
-    for dotted in unknown:
-        parts = dotted.split(".")
-        container = doc
-        for part in parts[:-1]:
-            container = container[part]  # type: ignore[not-subscriptable]
-        key = parts[-1]
-        value = container[key]  # type: ignore[not-subscriptable]
-        del container[key]  # type: ignore[not-subscriptable]
-        # Serialize the value safely — tables/dicts can't use the simple split trick
-        try:
-            if isinstance(value, dict):
-                serialized = tomlkit.inline_table()
-                serialized.update(value)
-                value_str = str(serialized)
-            else:
-                value_str = tomlkit.dumps({"_": value}).split("= ", 1)[1].strip()
-                if "\n" in value_str:
-                    value_str = repr(value)
-        except Exception:
-            value_str = repr(value)
-        container.add(tomlkit.comment(f"DEPRECATED: {key} = {value_str}"))  # type: ignore[possibly-missing-attribute]
-
-    target.write_text(tomlkit.dumps(doc), encoding="utf-8")
-    return unknown
-
-
-def _remove_unknown_keys(target: Path) -> list[str]:
-    """Remove unknown keys from a config file using tomlkit (style-preserving).
-
-    Returns list of dotted key paths that were removed.
-    """
-    import tomlkit  # noqa: PLC0415
-
-    raw = target.read_text(encoding="utf-8")
-    data = tomllib.loads(raw)
-    unknown = _collect_unknown_keys(data, Config)
-    if not unknown:
-        return []
-
-    doc = tomlkit.loads(raw)
-    for dotted in unknown:
-        parts = dotted.split(".")
-        container = doc
-        for part in parts[:-1]:
-            container = container[part]  # type: ignore[not-subscriptable]
-        del container[parts[-1]]  # type: ignore[not-subscriptable]
-
-    target.write_text(tomlkit.dumps(doc), encoding="utf-8")
-    return unknown
-
-
-def update_config(cwd: Path | None = None) -> tuple[Path, list[str], list[str]]:
-    """Append missing sections and comment out deprecated keys.
-
-    Reads the current config file, checks which template sections are
-    missing, appends them, and comments out any unrecognized keys.
-
-    Raises ``SystemExit(1)`` if the config file doesn't exist.
-
-    Returns:
-        Tuple of (config path, list of added section headers, list of deprecated keys commented out).
-    """
-    target = (cwd or Path.cwd()) / CONFIG_FILENAME
-    if not target.exists():
-        print(f"Error: {CONFIG_FILENAME} not found in {target.parent}")  # noqa: T201
-        print("Hint: use 'codereviewbuddy config --init' to create one")  # noqa: T201
-        raise SystemExit(1)
-
-    # Comment out deprecated keys first
-    deprecated = _comment_out_unknown_keys(target)
-    if deprecated:
-        print(f"Commented out {len(deprecated)} deprecated key(s):")  # noqa: T201
-        for d in deprecated:
-            print(f"  # {d}")  # noqa: T201
-
-    existing = target.read_text(encoding="utf-8")
-    added: list[str] = []
-
-    for header, _block in _TEMPLATE_SECTIONS:
-        if header not in existing:
-            added.append(header)
-
-    if added:
-        # Ensure file ends with a newline before appending
-        appendix = "" if existing.endswith("\n") else "\n"
-        appendix += "\n# --- New sections added by 'codereviewbuddy config --update' ---\n\n"
-        for header, block in _TEMPLATE_SECTIONS:
-            if header in added:
-                appendix += block + "\n"
-
-        target.write_text(existing + appendix, encoding="utf-8")
-        print(f"Added {len(added)} section(s):")  # noqa: T201
-        for h in added:
-            print(f"  + {h}")  # noqa: T201
-
-    if not added and not deprecated:
-        print(f"{CONFIG_FILENAME} is up to date — nothing to change")  # noqa: T201
-
-    return target, added, deprecated
-
-
-def clean_config(cwd: Path | None = None) -> tuple[Path, list[str]]:
-    """Remove deprecated keys from an existing ``.codereviewbuddy.toml``.
-
-    Unlike ``update_config`` which comments out deprecated keys, this
-    removes them entirely for a tidy config file.
-
-    Raises ``SystemExit(1)`` if the config file doesn't exist.
-
-    Returns:
-        Tuple of (config path, list of removed key paths).
-    """
-    target = (cwd or Path.cwd()) / CONFIG_FILENAME
-    if not target.exists():
-        print(f"Error: {CONFIG_FILENAME} not found in {target.parent}")  # noqa: T201
-        print("Hint: use 'codereviewbuddy config --init' to create one")  # noqa: T201
-        raise SystemExit(1)
-
-    removed = _remove_unknown_keys(target)
-    if removed:
-        print(f"Removed {len(removed)} deprecated key(s) from {target}:")  # noqa: T201
-        for r in removed:
-            print(f"  - {r}")  # noqa: T201
-    else:
-        print(f"{CONFIG_FILENAME} is clean — no deprecated keys found")  # noqa: T201
-
-    return target, removed
+def set_config(config: Config) -> None:
+    """Set the active configuration (called during server startup)."""
+    global _active_config  # noqa: PLW0603
+    _active_config = config

--- a/src/codereviewbuddy/io_tap.py
+++ b/src/codereviewbuddy/io_tap.py
@@ -5,8 +5,8 @@ level, before the MCP library touches them. This provides a ground-truth
 audit trail for diagnosing transport hangs (issue #65).
 
 Logs are written to ~/.codereviewbuddy/io_tap.jsonl.
-Enable via ``[diagnostics] io_tap = true`` in .codereviewbuddy.toml,
-or the CODEREVIEWBUDDY_IO_TAP=1 environment variable (overrides config).
+Enable via ``CRB_DIAGNOSTICS__IO_TAP=true`` environment variable,
+or the CODEREVIEWBUDDY_IO_TAP=1 environment variable (legacy override).
 """
 
 from __future__ import annotations
@@ -257,7 +257,7 @@ def _should_enable_io_tap() -> bool:
     try:
         from codereviewbuddy.config import load_config  # noqa: PLC0415
 
-        config, _path = load_config()
+        config = load_config()
     except Exception:
         return False
     else:
@@ -267,8 +267,8 @@ def _should_enable_io_tap() -> bool:
 def install_io_tap() -> bool:
     """Install I/O tap on stdin/stdout if enabled via config or env var.
 
-    Checks ``CODEREVIEWBUDDY_IO_TAP`` env var first (overrides config),
-    then falls back to ``[diagnostics] io_tap`` in .codereviewbuddy.toml.
+    Checks ``CODEREVIEWBUDDY_IO_TAP`` env var first (legacy override),
+    then falls back to ``CRB_DIAGNOSTICS__IO_TAP`` env var.
 
     Must be called BEFORE FastMCP starts the stdio transport.
     Returns True if the tap was installed, False otherwise.

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -189,5 +189,4 @@ class ConfigInfo(BaseModel):
     """Active codereviewbuddy configuration with metadata."""
 
     config: dict = Field(description="Full configuration as a dictionary")
-    config_path: str | None = Field(default=None, description="Path to the .codereviewbuddy.toml file, or null if using defaults")
-    hot_reload: bool = Field(default=False, description="Whether config changes are automatically picked up")
+    source: str = Field(default="env", description="Configuration source: 'env' (CRB_* environment variables)")

--- a/src/codereviewbuddy/reviewers/base.py
+++ b/src/codereviewbuddy/reviewers/base.py
@@ -17,7 +17,7 @@ class ReviewerAdapter(ABC):
     comments, and how to identify its comments by author username.
 
     Call :meth:`configure` to apply per-reviewer config overrides from
-    ``.codereviewbuddy.toml``.  Without configuration, adapters use their
+    ``CRB_*`` env vars.  Without configuration, adapters use their
     hardcoded defaults.
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,8 @@ from codereviewbuddy.config import Config, set_config
 def _default_config():
     """Reset config to defaults before every test.
 
-    The committed .codereviewbuddy.toml may disable reviewers (e.g. Devin),
-    which breaks tests that expect all reviewers enabled. This fixture
-    ensures every test starts with a clean default config.
+    Ensures every test starts with a clean default config, unaffected
+    by CRB_* env vars that may be set in the developer's shell.
     """
     set_config(Config())
     yield

--- a/tests/test_io_tap.py
+++ b/tests/test_io_tap.py
@@ -395,7 +395,7 @@ class TestShouldEnableIoTap:
         from codereviewbuddy.config import Config, DiagnosticsConfig
 
         mock_config = Config(diagnostics=DiagnosticsConfig(io_tap=True))
-        mocker.patch("codereviewbuddy.config.load_config", return_value=(mock_config, None))
+        mocker.patch("codereviewbuddy.config.load_config", return_value=mock_config)
         assert _should_enable_io_tap() is False
 
     def test_config_enables_when_no_env_var(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
@@ -403,7 +403,7 @@ class TestShouldEnableIoTap:
         from codereviewbuddy.config import Config, DiagnosticsConfig
 
         mock_config = Config(diagnostics=DiagnosticsConfig(io_tap=True))
-        mocker.patch("codereviewbuddy.config.load_config", return_value=(mock_config, None))
+        mocker.patch("codereviewbuddy.config.load_config", return_value=mock_config)
         assert _should_enable_io_tap() is True
 
     def test_defaults_false_when_no_env_and_no_config(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -100,7 +100,7 @@ async def client(mocker: MockerFixture):
     from codereviewbuddy.config import Config
 
     mocker.patch("codereviewbuddy.server.check_prerequisites")
-    mocker.patch("codereviewbuddy.server.load_config", return_value=(Config(), None))
+    mocker.patch("codereviewbuddy.server.load_config", return_value=Config())
     async with Client(mcp) as c:
         yield c
 
@@ -395,8 +395,7 @@ class TestShowConfigMCP:
 
         data = json.loads(result.content[0].text)  # type: ignore[unresolved-attribute]
         assert "config" in data
-        assert "config_path" in data
-        assert "hot_reload" in data
+        assert "source" in data
         # Config should have the expected top-level keys
         assert "reviewers" in data["config"]
         assert "self_improvement" in data["config"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,13 +7,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest_mock import MockerFixture
 
-from codereviewbuddy.config import CONFIG_FILENAME, init_config, update_config
 from codereviewbuddy.gh import GhError, GhNotAuthenticatedError, GhNotFoundError
-from codereviewbuddy.server import _config_cmd, _get_workspace_cwd, _resolve_pr_number, check_fastmcp_runtime, check_prerequisites
+from codereviewbuddy.server import _get_workspace_cwd, _resolve_pr_number, check_fastmcp_runtime, check_prerequisites
 
 
 class TestCheckPrerequisites:
@@ -55,81 +52,6 @@ class TestCheckFastMcpRuntime:
             check_fastmcp_runtime()
 
 
-class TestInitConfig:
-    def test_creates_config_file(self, tmp_path: Path):
-        path = init_config(cwd=tmp_path)
-        assert path.exists()
-        content = path.read_text(encoding="utf-8")
-        assert "[reviewers.devin]" in content
-        assert "[pr_descriptions]" in content
-        assert "[self_improvement]" in content
-        assert "[diagnostics]" in content
-        assert "io_tap = true" in content
-        assert 'repo = "detailobsessed/codereviewbuddy"' in content
-
-    def test_fails_if_file_exists(self, tmp_path: Path):
-        (tmp_path / CONFIG_FILENAME).write_text("existing", encoding="utf-8")
-        with pytest.raises(SystemExit):
-            init_config(cwd=tmp_path)
-
-    def test_hint_mentions_update(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        (tmp_path / CONFIG_FILENAME).write_text("existing", encoding="utf-8")
-        with pytest.raises(SystemExit):
-            init_config(cwd=tmp_path)
-        assert "--update" in capsys.readouterr().out
-
-
-class TestUpdateConfig:
-    def test_appends_missing_sections(self, tmp_path: Path):
-        config_file = tmp_path / CONFIG_FILENAME
-        config_file.write_text("[reviewers.devin]\nenabled = true\n", encoding="utf-8")
-        _, added, _deprecated = update_config(cwd=tmp_path)
-        assert "[pr_descriptions]" in added
-        assert "[reviewers.unblocked]" in added
-        assert "[reviewers.devin]" not in added  # already existed
-        updated = config_file.read_text(encoding="utf-8")
-        assert "[pr_descriptions]" in updated
-        assert "enabled = true" in updated  # original value preserved
-
-    def test_no_changes_when_up_to_date(self, tmp_path: Path):
-        init_config(cwd=tmp_path)
-        _, added, deprecated = update_config(cwd=tmp_path)
-        assert added == []
-        assert deprecated == []
-
-    def test_fails_if_no_config(self, tmp_path: Path):
-        with pytest.raises(SystemExit):
-            update_config(cwd=tmp_path)
-
-    def test_hint_mentions_init(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        with pytest.raises(SystemExit):
-            update_config(cwd=tmp_path)
-        assert "--init" in capsys.readouterr().out
-
-
-class TestConfigCmd:
-    def test_no_flags_shows_usage(self):
-        with pytest.raises(SystemExit):
-            _config_cmd([])
-
-    def test_init_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.chdir(tmp_path)
-        _config_cmd(["--init"])
-        assert (tmp_path / CONFIG_FILENAME).exists()
-
-    def test_update_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.chdir(tmp_path)
-        (tmp_path / CONFIG_FILENAME).write_text("[reviewers.devin]\n", encoding="utf-8")
-        _config_cmd(["--update"])
-
-    def test_clean_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.chdir(tmp_path)
-        (tmp_path / CONFIG_FILENAME).write_text("[pr_descriptions]\nrequire_review = false\n", encoding="utf-8")
-        _config_cmd(["--clean"])
-        content = (tmp_path / CONFIG_FILENAME).read_text(encoding="utf-8")
-        assert "require_review" not in content
-
-
 class TestResolvePrNumber:
     def test_returns_explicit_number(self):
         assert _resolve_pr_number(42) == 42
@@ -148,14 +70,6 @@ class TestResolvePrNumber:
 
 
 class TestMain:
-    def test_config_init_subcommand(self, mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.chdir(tmp_path)
-        mocker.patch("sys.argv", ["codereviewbuddy", "config", "--init"])
-        from codereviewbuddy.server import main
-
-        main()
-        assert (tmp_path / CONFIG_FILENAME).exists()
-
     def test_run_server(self, mocker: MockerFixture):
         mocker.patch("sys.argv", ["codereviewbuddy"])
         mock_run = mocker.patch("codereviewbuddy.server.mcp.run")
@@ -167,16 +81,32 @@ class TestMain:
 
 
 class TestGetWorkspaceCwd:
-    """Tests for _get_workspace_cwd — MCP roots → cwd extraction (#142)."""
+    """Tests for _get_workspace_cwd — env var → MCP roots → None cascade (#142)."""
 
-    async def test_returns_none_without_context(self):
-        assert await _get_workspace_cwd(None) is None
-
-    async def test_extracts_path_from_file_root(self, mocker: MockerFixture):
+    async def test_env_var_takes_priority(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
 
         from pydantic import FileUrl
 
+        monkeypatch.setenv("CRB_WORKSPACE", "/from/env")
+        root = mocker.MagicMock()
+        root.uri = FileUrl("file:///from/roots")
+        ctx = mocker.MagicMock()
+        ctx.list_roots = AsyncMock(return_value=[root])
+
+        result = await _get_workspace_cwd(ctx)
+        assert result == "/from/env"
+
+    async def test_env_var_without_context(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CRB_WORKSPACE", "/from/env")
+        assert await _get_workspace_cwd(None) == "/from/env"
+
+    async def test_roots_used_when_no_env_var(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+        from unittest.mock import AsyncMock
+
+        from pydantic import FileUrl
+
+        monkeypatch.delenv("CRB_WORKSPACE", raising=False)
         root = mocker.MagicMock()
         root.uri = FileUrl("file:///Users/alice/repos/myproject")
         ctx = mocker.MagicMock()
@@ -185,17 +115,23 @@ class TestGetWorkspaceCwd:
         result = await _get_workspace_cwd(ctx)
         assert result == "/Users/alice/repos/myproject"
 
-    async def test_returns_none_when_roots_empty(self, mocker: MockerFixture):
+    async def test_returns_none_without_context(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("CRB_WORKSPACE", raising=False)
+        assert await _get_workspace_cwd(None) is None
+
+    async def test_returns_none_when_roots_empty(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
 
+        monkeypatch.delenv("CRB_WORKSPACE", raising=False)
         ctx = mocker.MagicMock()
         ctx.list_roots = AsyncMock(return_value=[])
 
         assert await _get_workspace_cwd(ctx) is None
 
-    async def test_returns_none_on_exception(self, mocker: MockerFixture):
+    async def test_returns_none_on_roots_exception(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
 
+        monkeypatch.delenv("CRB_WORKSPACE", raising=False)
         ctx = mocker.MagicMock()
         ctx.list_roots = AsyncMock(side_effect=Exception("roots not supported"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,14 +34,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.7"
+version = "1.6.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/dc/ed1681bf1339dd6ea1ce56136bad4baabc6f7ad466e375810702b0237047/authlib-1.6.7.tar.gz", hash = "sha256:dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b", size = 164950, upload-time = "2026-02-06T14:04:14.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6c/c88eac87468c607f88bc24df1f3b31445ee6fc9ba123b09e666adf687cd9/authlib-1.6.8.tar.gz", hash = "sha256:41ae180a17cf672bc784e4a518e5c82687f1fe1e98b0cafaeda80c8e4ab2d1cb", size = 165074, upload-time = "2026-02-14T04:02:17.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/00/3ed12264094ec91f534fae429945efbaa9f8c666f3aa7061cc3b2a26a0cd/authlib-1.6.7-py2.py3-none-any.whl", hash = "sha256:c637340d9a02789d2efa1d003a7437d10d3e565237bcb5fcbc6c134c7b95bab0", size = 244115, upload-time = "2026-02-06T14:04:12.141Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/73/f7084bf12755113cd535ae586782ff3a6e710bfbe6a0d13d1c2f81ffbbfa/authlib-1.6.8-py2.py3-none-any.whl", hash = "sha256:97286fd7a15e6cfefc32771c8ef9c54f0ed58028f1322de6a2a7c969c3817888", size = 244116, upload-time = "2026-02-14T04:02:15.579Z" },
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
-    { name = "tomlkit" },
+    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -248,7 +248,7 @@ maintain = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.0rc1" },
-    { name = "tomlkit", specifier = ">=0.13" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.0.0rc1"
+version = "3.0.0rc2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -511,9 +511,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/f7/d3a51c4ce70683975b6f9c25df28057610e7eab6916941e1a74d9eb3bc15/fastmcp-3.0.0rc1.tar.gz", hash = "sha256:26202810a7b844e392c2a6e09a8b5ff7a4735e4a4e75db89b52813a5bf2b5b4f", size = 14258063, upload-time = "2026-02-12T22:42:37.229Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/3a/afa90e3646b754d52cd8a436490ffed38bc9fd0d605f479d04de38af1dee/fastmcp-3.0.0rc2.tar.gz", hash = "sha256:81cc408b13a0ab2e7701abaa04c8a64597e13bb2fec2a7fc92fd324e08855ef2", size = 14258553, upload-time = "2026-02-14T03:57:09.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b9/2e9ab2afc9093889a01f7b56c4b3083ffa4b43c30f473bad32c4180332c5/fastmcp-3.0.0rc1-py3-none-any.whl", hash = "sha256:5b9aae094917081e63f3881fb5e2073a3d6d84beff2f2aabcb16277618154430", size = 601102, upload-time = "2026-02-12T22:42:39.574Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7b/556317e567956fb6108f981d63a48be69e5e0014ae745f4feb3f50a1da4e/fastmcp-3.0.0rc2-py3-none-any.whl", hash = "sha256:0596b372c4b6b193f02619a874dca3550b153b085827e82133ccfef2bb687a3d", size = 601390, upload-time = "2026-02-14T03:57:07.277Z" },
 ]
 
 [[package]]
@@ -1239,11 +1239,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.7.0"
+version = "4.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/25/ccd8e88fcd16a4eb6343a8b4b9635e6f3928a7ebcd82822a14d20e3ca29f/platformdirs-4.7.0.tar.gz", hash = "sha256:fd1a5f8599c85d49b9ac7d6e450bc2f1aaf4a23f1fe86d09952fe20ad365cf36", size = 23118, upload-time = "2026-02-12T22:21:53.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/e3/1eddccb2c39ecfbe09b3add42a04abcc3fa5b468aa4224998ffb8a7e9c8f/platformdirs-4.7.0-py3-none-any.whl", hash = "sha256:1ed8db354e344c5bb6039cd727f096af975194b508e37177719d562b2b540ee6", size = 18983, upload-time = "2026-02-12T22:21:52.237Z" },
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
 ]
 
 [[package]]
@@ -1270,39 +1270,39 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.3.2"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/f5/ee52def928dd1355c20bcfcf765e1e61434635c33f3075e848e7b83a157b/prek-0.3.2.tar.gz", hash = "sha256:dce0074ff1a21290748ca567b4bda7553ee305a8c7b14d737e6c58364a499364", size = 334229, upload-time = "2026-02-06T13:49:47.539Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/f1/7613dc8347a33e40fc5b79eec6bc7d458d8bbc339782333d8433b665f86f/prek-0.3.3.tar.gz", hash = "sha256:117bd46ebeb39def24298ce021ccc73edcf697b81856fcff36d762dd56093f6f", size = 343697, upload-time = "2026-02-15T13:33:28.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/69/70a5fc881290a63910494df2677c0fb241d27cfaa435bbcd0de5cd2e2443/prek-0.3.2-py3-none-linux_armv6l.whl", hash = "sha256:4f352f9c3fc98aeed4c8b2ec4dbf16fc386e45eea163c44d67e5571489bd8e6f", size = 4614960, upload-time = "2026-02-06T13:50:05.818Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/15/a82d5d32a2207ccae5d86ea9e44f2b93531ed000faf83a253e8d1108e026/prek-0.3.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4a000cfbc3a6ec7d424f8be3c3e69ccd595448197f92daac8652382d0acc2593", size = 4622889, upload-time = "2026-02-06T13:49:53.662Z" },
-    { url = "https://files.pythonhosted.org/packages/89/75/ea833b58a12741397017baef9b66a6e443bfa8286ecbd645d14111446280/prek-0.3.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5436bdc2702cbd7bcf9e355564ae66f8131211e65fefae54665a94a07c3d450a", size = 4239653, upload-time = "2026-02-06T13:50:02.88Z" },
-    { url = "https://files.pythonhosted.org/packages/10/b4/d9c3885987afac6e20df4cb7db14e3b0d5a08a77ae4916488254ebac4d0b/prek-0.3.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:0161b5f584f9e7f416d6cf40a17b98f17953050ff8d8350ec60f20fe966b86b6", size = 4595101, upload-time = "2026-02-06T13:49:49.813Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a6/1a06473ed83dbc898de22838abdb13954e2583ce229f857f61828384634c/prek-0.3.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4e641e8533bca38797eebb49aa89ed0e8db0e61225943b27008c257e3af4d631", size = 4521978, upload-time = "2026-02-06T13:49:41.266Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5e/c38390d5612e6d86b32151c1d2fdab74a57913473193591f0eb00c894c21/prek-0.3.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfca1810d49d3f9ef37599c958c4e716bc19a1d78a7e88cbdcb332e0b008994f", size = 4829108, upload-time = "2026-02-06T13:49:44.598Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a6/cecce2ab623747ff65ed990bb0d95fa38449ee19b348234862acf9392fff/prek-0.3.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d69d754299a95a85dc20196f633232f306bee7e7c8cba61791f49ce70404ec", size = 5357520, upload-time = "2026-02-06T13:49:48.512Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/18/d6bcb29501514023c76d55d5cd03bdbc037737c8de8b6bc41cdebfb1682c/prek-0.3.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:539dcb90ad9b20837968539855df6a29493b328a1ae87641560768eed4f313b0", size = 4852635, upload-time = "2026-02-06T13:49:58.347Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/0a/ae46f34ba27ba87aea5c9ad4ac9cd3e07e014fd5079ae079c84198f62118/prek-0.3.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1998db3d0cbe243984736c82232be51318f9192e2433919a6b1c5790f600b5fd", size = 4599484, upload-time = "2026-02-06T13:49:43.296Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/a9/73bfb5b3f7c3583f9b0d431924873928705cdef6abb3d0461c37254a681b/prek-0.3.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:07ab237a5415a3e8c0db54de9d63899bcd947624bdd8820d26f12e65f8d19eb7", size = 4657694, upload-time = "2026-02-06T13:50:01.074Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/bc/0994bc176e1a80110fad3babce2c98b0ac4007630774c9e18fc200a34781/prek-0.3.2-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:0ced19701d69c14a08125f14a5dd03945982edf59e793c73a95caf4697a7ac30", size = 4509337, upload-time = "2026-02-06T13:49:54.891Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/13/e73f85f65ba8f626468e5d1694ab3763111513da08e0074517f40238c061/prek-0.3.2-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ffb28189f976fa111e770ee94e4f298add307714568fb7d610c8a7095cb1ce59", size = 4697350, upload-time = "2026-02-06T13:50:04.526Z" },
-    { url = "https://files.pythonhosted.org/packages/14/47/98c46dcd580305b9960252a4eb966f1a7b1035c55c363f378d85662ba400/prek-0.3.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:f63134b3eea14421789a7335d86f99aee277cb520427196f2923b9260c60e5c5", size = 4955860, upload-time = "2026-02-06T13:49:56.581Z" },
-    { url = "https://files.pythonhosted.org/packages/73/42/1bb4bba3ff47897df11e9dfd774027cdfa135482c961a54e079af0faf45a/prek-0.3.2-py3-none-win32.whl", hash = "sha256:58c806bd1344becd480ef5a5ba348846cc000af0e1fbe854fef91181a2e06461", size = 4267619, upload-time = "2026-02-06T13:49:39.503Z" },
-    { url = "https://files.pythonhosted.org/packages/97/11/6665f47a7c350d83de17403c90bbf7a762ef50876ece456a86f64f46fbfb/prek-0.3.2-py3-none-win_amd64.whl", hash = "sha256:70114b48e9eb8048b2c11b4c7715ce618529c6af71acc84dd8877871a2ef71a6", size = 4624324, upload-time = "2026-02-06T13:49:45.922Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e7/740997ca82574d03426f897fd88afe3fc8a7306b8c7ea342a8bc1c538488/prek-0.3.2-py3-none-win_arm64.whl", hash = "sha256:9144d176d0daa2469a25c303ef6f6fa95a8df015eb275232f5cb53551ecefef0", size = 4336008, upload-time = "2026-02-06T13:49:52.27Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8b/dce13d2a3065fd1e8ffce593a0e51c4a79c3cde9c9a15dc0acc8d9d1573d/prek-0.3.3-py3-none-linux_armv6l.whl", hash = "sha256:e8629cac4bdb131be8dc6e5a337f0f76073ad34a8305f3fe2bc1ab6201ede0a4", size = 4644636, upload-time = "2026-02-15T13:33:43.609Z" },
+    { url = "https://files.pythonhosted.org/packages/01/30/06ab4dbe7ce02a8ce833e92deb1d9a8e85ae9d40e33d1959a2070b7494c6/prek-0.3.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4b9e819b9e4118e1e785047b1c8bd9aec7e4d836ed034cb58b7db5bcaaf49437", size = 4651410, upload-time = "2026-02-15T13:33:34.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fc/da3bc5cb38471e7192eda06b7a26b7c24ef83e82da2c1dbc145f2bf33640/prek-0.3.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bf29db3b5657c083eb8444c25aadeeec5167dc492e9019e188f87932f01ea50a", size = 4273163, upload-time = "2026-02-15T13:33:42.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/74/47839395091e2937beced81a5dd2f8ea9c8239c853da8611aaf78ee21a8b/prek-0.3.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:ae09736149815b26e64a9d350ca05692bab32c2afdf2939114d3211aaad68a3e", size = 4631808, upload-time = "2026-02-15T13:33:20.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/89/3f5ef6f7c928c017cb63b029349d6bc03598ab7f6979d4a770ce02575f82/prek-0.3.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:856c2b55c51703c366bb4ce81c6a91102b70573a9fc8637db2ac61c66e4565f9", size = 4548959, upload-time = "2026-02-15T13:33:36.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/18/80002c4c4475f90ca025f27739a016927a0e5d905c60612fc95da1c56ab7/prek-0.3.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3acdf13a018f685beaff0a71d4b0d2ccbab4eaa1aced6d08fd471c1a654183eb", size = 4862256, upload-time = "2026-02-15T13:33:37.754Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/25/648bf084c2468fa7cfcdbbe9e59956bbb31b81f36e113bc9107d80af26a7/prek-0.3.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0f035667a8bd0a77b2bfa2b2e125da8cb1793949e9eeef0d8daab7f8ac8b57fe", size = 5404486, upload-time = "2026-02-15T13:33:39.239Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/43/261fb60a11712a327da345912bd8b338dc5a050199de800faafa278a6133/prek-0.3.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d09b2ad14332eede441d977de08eb57fb3f61226ed5fd2ceb7aadf5afcdb6794", size = 4887513, upload-time = "2026-02-15T13:33:40.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/581e757ee57ec6046b32e0ee25660fc734bc2622c319f57119c49c0cab58/prek-0.3.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:c0c3ffac16e37a9daba43a7e8316778f5809b70254be138761a8b5b9ef0df28e", size = 4632336, upload-time = "2026-02-15T13:33:25.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d8/aa276ce5d11b77882da4102ca0cb7161095831105043ae7979bbfdcc3dc4/prek-0.3.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a3dc7720b580c07c0386e17af2486a5b4bc2f6cc57034a288a614dcbc4abe555", size = 4679370, upload-time = "2026-02-15T13:33:22.247Z" },
+    { url = "https://files.pythonhosted.org/packages/70/19/9d4fa7bde428e58d9f48a74290c08736d42aeb5690dcdccc7a713e34a449/prek-0.3.3-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:60e0fa15da5020a03df2ee40268145ec5b88267ec2141a205317ad4df8c992d6", size = 4540316, upload-time = "2026-02-15T13:33:24.088Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b5/973cce29257e0b47b16cc9b4c162772ea01dbb7c080791ea0c068e106e05/prek-0.3.3-py3-none-musllinux_1_1_i686.whl", hash = "sha256:553515da9586d9624dc42db32b744fdb91cf62b053753037a0cadb3c2d8d82a2", size = 4724566, upload-time = "2026-02-15T13:33:29.832Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/ad8b2658895a8ed2b0bc630bf38686fe38b7ff2c619c58953a80e4de3048/prek-0.3.3-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:9512cf370e0d1496503463a4a65621480efb41b487841a9e9ff1661edf14b238", size = 4995072, upload-time = "2026-02-15T13:33:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b7/0540c101c00882adb9d30319d22d8f879413598269ecc60235e41875efd4/prek-0.3.3-py3-none-win32.whl", hash = "sha256:b2b328c7c6dc14ccdc79785348589aa39850f47baff33d8f199f2dee80ff774c", size = 4293144, upload-time = "2026-02-15T13:33:46.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/e4f11da653093040efba2d835aa0995d78940aea30887287aeaebe34a545/prek-0.3.3-py3-none-win_amd64.whl", hash = "sha256:3d7d7acf7ca8db65ba0943c52326c898f84bab0b1c26a35c87e0d177f574ca5f", size = 4652761, upload-time = "2026-02-15T13:33:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/11/e4/d99dec54c6a5fb2763488bff6078166383169a93f3af27d2edae88379a39/prek-0.3.3-py3-none-win_arm64.whl", hash = "sha256:8aa87ee7628cd74482c0dd6537a3def1f162b25cd642d78b1b35dd3e81817f60", size = 4367520, upload-time = "2026-02-15T13:33:31.664Z" },
 ]
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/42/4397b26c564a7428fbb424c353fc416c5954609c149b6d629255f65e6dc9/py_key_value_aio-0.4.0.tar.gz", hash = "sha256:55be4942bf5d5a40aa9d6eae443425096fe1bec6af7571502e54240ce3597189", size = 89104, upload-time = "2026-02-10T23:05:51.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/6b/fc3524e6ea04f5a00cb4cc8c09216fcb0fa0546267e07895ba87f8f7ffb2/py_key_value_aio-0.4.2.tar.gz", hash = "sha256:7bbe31d3ce8ee4f7802f34dcc12df23f0a9715c9660b7db34973bb28727dee1b", size = 91129, upload-time = "2026-02-16T02:02:39.796Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/34/83fb1612bfdd68ef6a47b036dd0f906f943dac10844b43242a5c39395013/py_key_value_aio-0.4.0-py3-none-any.whl", hash = "sha256:962fe40cb763b2853a8f7484e9271dcbd8bf41679f4c391e54bfee4a7ca89c84", size = 148756, upload-time = "2026-02-10T23:05:50.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/00/e280faf3b15a10eca20a8b68a1cbf1f9b42635a19b350a67ed7db02d3b28/py_key_value_aio-0.4.2-py3-none-any.whl", hash = "sha256:04dd01caec58819834f1256e56e4547da4b4f4fecad8784d5574fa5cba15ff82", size = 150703, upload-time = "2026-02-16T02:02:37.603Z" },
 ]
 
 [package.optional-dependencies]
@@ -1387,16 +1387,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
 ]
 
 [[package]]
@@ -1424,15 +1424,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20.1"
+version = "10.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
BREAKING CHANGE: Configuration is now via CRB_* environment variables
(pydantic-settings). Removed .codereviewbuddy.toml support, hot-reload,
and `codereviewbuddy config` CLI commands.

- Fix #142: CRB_WORKSPACE env var for workspace detection
- Replace tomlkit dep with pydantic-settings (same pattern as FastMCP)
- Update server instructions: explicit repo parameter warning
- Update README: env var table, CRB_WORKSPACE in all client examples
- Upgrade FastMCP 3.0.0rc1 → 3.0.0rc2

## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->
