### PR TITLE
fix: MCP roots take priority over CRB_WORKSPACE for multi-window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,14 @@ Add the following to your MCP client's config JSON (Windsurf, Claude Desktop, Cu
   "mcpServers": {
     "codereviewbuddy": {
       "command": "uvx",
-      "args": ["--prerelease=allow", "codereviewbuddy@latest"],
-      "env": {
-        "CRB_WORKSPACE": "/path/to/your/project"
-      }
+      "args": ["--prerelease=allow", "codereviewbuddy@latest"]
     }
   }
 }
 ```
 
-> **Why `CRB_WORKSPACE`?** The server needs to know which project you're working in so `gh` CLI commands target the right repo. Without this, auto-detection may pick the wrong repository.
->
+The server auto-detects your project from MCP roots (sent per-window by your client). This works correctly with multiple windows open on different projects — no env vars needed.
+
 > **Why `--prerelease=allow`?** codereviewbuddy depends on FastMCP v3 prerelease (`>=3.0.0rc1`). Without this flag, `uvx` refuses to resolve pre-release dependencies.
 >
 > **Why `@latest`?** Without it, `uvx` caches the first resolved version and never upgrades automatically.
@@ -109,9 +106,6 @@ For local development, use `uv run --directory` to run the server from your chec
       "command": "uv",
       "args": ["run", "--directory", "/path/to/codereviewbuddy", "codereviewbuddy"],
       "env": {
-        // Required: point at the repo you're reviewing PRs in
-        "CRB_WORKSPACE": "/path/to/your/project",
-
         // Self-improvement: agents file issues when they hit server gaps
         "CRB_SELF_IMPROVEMENT__ENABLED": "true",
         "CRB_SELF_IMPROVEMENT__REPO": "detailobsessed/codereviewbuddy",
@@ -160,7 +154,6 @@ codereviewbuddy works **zero-config** with sensible defaults. All configuration 
 
 | Env var | Type | Default | Description |
 | ------- | ---- | ------- | ----------- |
-| `CRB_WORKSPACE` | string | *(auto-detect)* | Project directory for `gh` CLI — set this to avoid wrong-repo detection |
 | `CRB_PR_DESCRIPTIONS__ENABLED` | bool | `true` | Whether `review_pr_descriptions` tool is available |
 | `CRB_SELF_IMPROVEMENT__ENABLED` | bool | `false` | Agents file issues when they encounter server gaps |
 | `CRB_SELF_IMPROVEMENT__REPO` | string | `""` | Repository to file issues against (e.g. `owner/repo`) |


### PR DESCRIPTION
## Summary

Flips workspace detection priority so MCP roots (per-window) take precedence over `CRB_WORKSPACE` (static env var). This fixes multi-window setups where a single shared MCP client config JSON would hardcode the wrong project path.

## Problem

`CRB_WORKSPACE` was priority #1 in workspace detection. But MCP client config JSON is shared across all IDE windows — setting a static project path breaks when you have multiple windows open on different projects simultaneously.

## Changes

- **`server.py`**: Flip `_get_workspace_cwd` priority: MCP roots → `CRB_WORKSPACE` → process cwd
- **`server.py`**: Update instructions to explain auto-detection from MCP roots
- **`README.md`**: Remove `CRB_WORKSPACE` from default config snippet and settings table — it is an internal fallback for CI/scripts, not user-facing config
- **`test_server.py`**: Rewrite `TestGetWorkspaceCwd` — roots now win over env var; added fallback tests for roots-empty and roots-exception cases (6 → 8 tests)

## Detection cascade

```
1. MCP roots    — per-window, sent by the client (correct for multi-window)
2. CRB_WORKSPACE — static env var fallback (CI, scripts)
3. process cwd  — weakest, almost never useful
```

Verified: Windsurf sends MCP roots correctly — workspace detection works across multiple windows without any env var config.