### PR TITLE
fix: apply _check_graphql_errors to query paths

### DIFF
--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -429,6 +429,7 @@ async def _fetch_raw_threads(
             variables["cursor"] = cursor
 
         result = await call_sync_fn_in_threadpool(gh.graphql, _THREADS_QUERY, variables=variables, cwd=cwd)
+        _check_graphql_errors(result, f"fetch review threads for PR #{pr_number} (page {page})")
         pr_data = result.get("data", {}).get("repository", {}).get("pullRequest") or {}
         threads_data = pr_data.get("reviewThreads", {})
         raw_threads.extend(threads_data.get("nodes", []))
@@ -601,6 +602,7 @@ def _fetch_thread_detail(thread_id: str, cwd: str | None = None) -> tuple[str, s
         (reviewer_name, comment_body, all_logins) — empty strings/list if lookup fails.
     """
     result = gh.graphql(_THREAD_DETAIL_QUERY, variables={"threadId": thread_id}, cwd=cwd)
+    _check_graphql_errors(result, f"fetch thread detail {thread_id}")
     node = result.get("data", {}).get("node") or {}
     comments = node.get("comments", {}).get("nodes", [])
     if not comments:


### PR DESCRIPTION
Apply `_check_graphql_errors` to the two GraphQL query paths that were missing error checks: `_fetch_raw_threads` and `_fetch_thread_detail`.

Previously, these functions silently swallowed GraphQL-level errors (e.g. auth failures, rate limits) because they only checked for data in the response without validating the `errors` field. Now both paths raise `GhError` with a descriptive message.

## Changes
- `_fetch_raw_threads`: added `_check_graphql_errors` after the paginated GraphQL call
- `_fetch_thread_detail`: added `_check_graphql_errors` after the thread detail query
- Tests: 3 new tests covering error and success paths

Fixes #145