### PR TITLE
feat: support dismissing PR-level reviews in resolve_comment

### DIFF
--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -307,12 +307,12 @@ async def resolve_comment(
 ) -> str:
     """Resolve a specific review thread by its ID.
 
-    Uses the resolveReviewThread GraphQL mutation (not minimizeComment).
-    Thread IDs have the PRRT_ prefix.
+    For inline threads (PRRT_), uses the resolveReviewThread GraphQL mutation.
+    For PR-level reviews (PRR_), dismisses the review via dismissPullRequestReview.
 
     Args:
         pr_number: PR number (for context). Auto-detected from current branch if omitted.
-        thread_id: The GraphQL node ID (PRRT_...) of the thread to resolve.
+        thread_id: The GraphQL node ID (PRRT_... or PRR_...) to resolve/dismiss.
     """
     try:
         ctx = get_context()


### PR DESCRIPTION
Extend `resolve_comment` to support dismissing PR-level reviews (`PRR_` IDs) via the `dismissPullRequestReview` GraphQL mutation, instead of rejecting them with an error.

## Changes
- New `_DISMISS_REVIEW_MUTATION` GraphQL mutation and `_dismiss_pr_review` helper
- `resolve_comment` now routes `PRR_` IDs to dismiss, `PRRT_` IDs to resolve, and rejects `IC_` IDs with a clear error
- Updated tool docstring in `server.py` to reflect PRR_ support
- Tests: dismiss success, dismiss failure, and IC_ rejection

Fixes #120