### PR TITLE
fix: per-PR error handling in review_pr_descriptions

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -111,6 +111,7 @@ class PRDescriptionInfo(BaseModel):
     missing_elements: list[str] = Field(
         default_factory=list, description="Missing quality elements (e.g. 'no linked issues', 'empty body')"
     )
+    error: str | None = Field(default=None, description="Error message if fetching this PR failed")
 
 
 class PRDescriptionReviewResult(BaseModel):

--- a/src/codereviewbuddy/tools/descriptions.py
+++ b/src/codereviewbuddy/tools/descriptions.py
@@ -123,8 +123,17 @@ async def review_pr_descriptions(
     for i, pr_number in enumerate(pr_numbers):
         if ctx and total:
             await ctx.report_progress(i, total)
-        data = await call_sync_fn_in_threadpool(_fetch_pr_info, pr_number, repo=repo, cwd=cwd)
-        descriptions.append(_analyze_pr(data))
+        try:
+            data = await call_sync_fn_in_threadpool(_fetch_pr_info, pr_number, repo=repo, cwd=cwd)
+            descriptions.append(_analyze_pr(data))
+        except Exception as exc:
+            descriptions.append(
+                PRDescriptionInfo(
+                    pr_number=pr_number,
+                    title="",
+                    error=f"Failed to fetch PR #{pr_number}: {exc}",
+                )
+            )
 
     if ctx and total:
         await ctx.report_progress(total, total)


### PR DESCRIPTION
Wrap the per-PR `_fetch_pr_info` call in `review_pr_descriptions` with a try/except so that one failing PR doesn't break the entire batch.

Failed PRs get a `PRDescriptionInfo` with an `error` field describing the failure, while successful PRs are analyzed normally.

## Changes
- `PRDescriptionInfo`: added optional `error` field
- `review_pr_descriptions`: wrapped `_fetch_pr_info` in try/except per iteration
- Test: verifies mixed success/failure batch returns all 3 results with correct error on the failing PR

Fixes #79