### PR TITLE
build: copier update from template 0.29.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,12 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.27.11
+_commit: 0.29.1
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic
 author_username: ichoosetoaccept
+cli_framework: none
 copyright_license: ISC
+custom_pypi_index_url: ''
 project_description: codereview buddy helps your AI agent interact with AI code review--smoothly!
 project_name: codereviewbuddy
 project_type: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,3 +165,14 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+
+  ci-pass:
+    if: always()
+    needs: [links, quality, tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check all jobs passed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+      with:
+        allowed-skips: quality, tests
+        jobs: ${{ toJSON(needs) }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,8 @@
 # Contributing
 
-Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
+Contributions are welcome! Every little bit helps, and credit will always be given.
 
 ## Environment setup
-
-Nothing easier!
 
 Fork and clone the repository, then:
 
@@ -13,109 +11,37 @@ cd codereviewbuddy
 uv sync
 ```
 
-> NOTE: If it fails for some reason, you'll need to install [uv](https://github.com/astral-sh/uv) manually.
->
-> You can install it with:
->
-> ```bash
-> curl -LsSf https://astral.sh/uv/install.sh | sh
-> ```
->
-> Now you can try running `uv sync` again.
+This installs all dependencies including dev tools. If `uv` is not installed, see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
-You now have the dependencies installed.
-
-You can run the application with `uv run codereviewbuddy`.
-
-Run `poe --help` to see all the available tasks!
+Run the CLI with `uv run codereviewbuddy [ARGS...]`.
 
 ## Tasks
 
-The project uses [poe the poet](https://github.com/nat-n/poethepoet) as a task runner. Tasks are defined in `pyproject.toml` under the `[tool.poe.tasks]` section. Run `poe` to list all available tasks.
+This project uses [poethepoet](https://github.com/nat-n/poethepoet) as a task runner. Run `poe` to list all available tasks. Key tasks:
 
-If you work in VSCode, we provide [tasks](https://code.visualstudio.com/docs/editor/tasks) that you can run from the command palette (Ctrl+Shift+P > Tasks: Run Task).
+- `poe check` — lint + type check (parallel)
+- `poe fix` — auto-fix lint issues and format
+- `poe test` — run tests (excluding slow)
+- `poe docs` — serve documentation locally
 
 ## Development
 
-As usual:
+1. Create a branch: `git switch -c feature-or-bugfix-name`
+2. Make your changes
+3. Commit — git hooks automatically run formatting, linting, and tests
 
-1. create a new branch: `git switch -c feature-or-bugfix-name`
-1. edit the code and/or the documentation
+Don't worry about the changelog — it is generated automatically from commit messages.
 
-**Before committing:**
+## Commit messages
 
-1. run `poe format` to auto-format the code
-1. run `poe check` to run all quality checks (fix any warnings)
-1. run `poe test` to run the tests (fix any issues)
-1. if you updated the documentation or the project dependencies:
-    1. run `poe docs`
-    1. go to <http://localhost:8000> and check that everything looks good
-1. follow our [commit message convention](#commit-message-convention)
-
-If you are unsure about how to fix or ignore a warning, just let the continuous integration fail, and we will help you during review.
-
-Don't bother updating the changelog, we will take care of this.
-
-## Commit message convention
-
-Commit messages must follow our convention based on the [Angular style](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message) or the [Karma convention](https://karma-runner.github.io/4.0/dev/git-commit-msg.html):
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). A git hook enforces the format, so you'll get immediate feedback if the message doesn't match:
 
 ```
 <type>[(scope)]: Subject
-
-[Body]
 ```
 
-**Subject and body must be valid Markdown.** Subject must have proper casing (uppercase for first letter if it makes sense), but no dot at the end, and no punctuation in general.
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `perf`.
 
-Scope and body are optional. Type can be:
+## Pull requests
 
-- `build`: About packaging, building wheels, etc.
-- `chore`: About packaging or repo/files management.
-- `ci`: About Continuous Integration.
-- `deps`: Dependencies update.
-- `docs`: About documentation.
-- `feat`: New feature.
-- `fix`: Bug fix.
-- `perf`: About performance.
-- `refactor`: Changes that are not features or bug fixes.
-- `style`: A change in code style/format.
-- `tests`: About tests.
-
-If you write a body, please add trailers at the end (for example issues and PR references, or co-authors), without relying on GitHub's flavored Markdown:
-
-```
-Body.
-
-Issue #10: https://github.com/namespace/project/issues/10
-Related to PR namespace/other-project#15: https://github.com/namespace/other-project/pull/15
-```
-
-These "trailers" must appear at the end of the body, without any blank lines between them. The trailer title can contain any character except colons `:`. We expect a full URI for each trailer, not just GitHub autolinks (for example, full GitHub URLs for commits and issues, not the hash or the #issue-number).
-
-We do not enforce a line length on commit messages summary and body, but please avoid very long summaries, and very long lines in the body, unless they are part of code blocks that must not be wrapped.
-
-## Pull requests guidelines
-
-Link to any related issue in the Pull Request message.
-
-During the review, we recommend using fixups:
-
-```bash
-# SHA is the SHA of the commit you want to fix
-git commit --fixup=SHA
-```
-
-Once all the changes are approved, you can squash your commits:
-
-```bash
-git rebase -i --autosquash main
-```
-
-And force-push:
-
-```bash
-git push -f
-```
-
-If this seems all too complicated, you can push or force-push each new commit, and we will squash them ourselves if needed, before merging.
+Link to any related issue in the PR description. Keep commits focused — one logical change per commit. We squash-merge PRs, so don't worry about a clean commit history within the PR.

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -5,7 +5,7 @@ and kept up to date on every `copier update`. Your project README lives in `READ
 
 ## Badges
 
-Copy these into your `README.md` to show project status on GitHub:
+Copy these into your `README.md` to show project status:
 
 ```markdown
 [![ci](https://github.com/detailobsessed/codereviewbuddy/workflows/ci/badge.svg)](https://github.com/detailobsessed/codereviewbuddy/actions?query=workflow%3Aci)

--- a/prek.toml
+++ b/prek.toml
@@ -111,20 +111,22 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-testmon"
 name = "pytest affected tests"
-entry = "uv run pytest --testmon --no-cov"
+entry = "uv run pytest -q --testmon --no-cov"
 language = "system"
 types = ["python"]
 pass_filenames = false
+verbose = true
 stages = ["pre-commit"]
 priority = 1
 
 [[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
-entry = "uv run pytest --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
+entry = "uv run pytest -q --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
 language = "system"
 types = ["python"]
 pass_filenames = false
+verbose = true
 stages = ["pre-push"]
 priority = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,67 +84,71 @@ preview = true
 
 [tool.ruff.lint]
 select = [
-    # Core (ruff defaults)
+    # Core — universal baseline (ruff defaults + pycodestyle warnings)
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings
     "F",    # Pyflakes
 
-    # Modern Python
-    "UP",   # pyupgrade - use modern Python syntax
-    "I",    # isort - import sorting
+    # Modern Python — enforce current idioms
+    "UP",   # pyupgrade — use modern syntax (match, type unions, etc.)
+    "I",    # isort — deterministic import ordering
+    "FA",   # flake8-future-annotations — `from __future__ import annotations`
 
-    # Code quality
-    "A",    # flake8-builtins - prevent shadowing builtins (id, type, list, etc.)
-    "B",    # flake8-bugbear - common bugs and design issues
-    "SIM",  # flake8-simplify - simplify code
-    "C4",   # flake8-comprehensions - better comprehensions
-    "PIE",  # flake8-pie - misc improvements
-    "RET",  # flake8-return - return statement issues
-    "RSE",  # flake8-raise - raise best practices
+    # Code quality — catch bugs and enforce clean patterns
+    "A",    # flake8-builtins — prevent shadowing builtins (id, type, list)
+    "B",    # flake8-bugbear — common bugs and design issues
+    "SIM",  # flake8-simplify — simplifiable constructs
+    "C4",   # flake8-comprehensions — better comprehensions
+    "PIE",  # flake8-pie — misc quality improvements
+    "RET",  # flake8-return — consistent return statements
+    "RSE",  # flake8-raise — raise best practices
+    "ISC",  # flake8-implicit-str-concat — catch missing commas in collections
     "RUF",  # Ruff-specific rules
-    "FA",   # flake8-future-annotations
-    "ISC",  # flake8-implicit-str-concat - catch missing commas
-    "ICN",  # flake8-import-conventions
-    "TID",  # flake8-tidy-imports - absolute imports
-    "TC",   # flake8-type-checking - TYPE_CHECKING imports
-    "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
-    "FURB", # refurb - modernize and simplify code
-    "FLY",  # flynt - prefer f-strings over .format() and %
+    "FURB", # refurb — modernise and simplify code
+    "FLY",  # flynt — prefer f-strings over .format() and %
+    "PGH",  # pygrep-hooks — catch bare `# type: ignore`, eval(), etc.
 
-    # Naming
-    # "N",  # pep8-naming - PEP 8 naming conventions (enable when ready)
+    # Import hygiene
+    "ICN",  # flake8-import-conventions — enforce standard aliases (np, pd)
+    "TID",  # flake8-tidy-imports — ban relative imports, enforce absolute
+    "TC",   # flake8-type-checking — move imports behind TYPE_CHECKING
 
-    # Datetime
-    "DTZ",  # flake8-datetimez - enforce timezone-aware datetimes
+    # Naming — currently disabled; enable once existing code conforms
+    # "N",  # pep8-naming — PEP 8 naming conventions
+
+    # Correctness
+    "DTZ",  # flake8-datetimez — enforce timezone-aware datetimes
+    "PTH",  # flake8-use-pathlib — prefer pathlib over os.path
 
     # Error messages
-    "EM",   # flake8-errmsg - no string literals in exceptions
+    "EM",   # flake8-errmsg — variables in exception constructors (better tracebacks)
 
-    # Pylint
+    # Pylint — uses default thresholds; do not inflate to hide violations
     "PLC",  # pylint conventions
     "PLE",  # pylint errors
     "PLR",  # pylint refactor (too-many-args, too-many-branches, etc.)
     "PLW",  # pylint warnings
 
     # Performance
-    "PERF", # Perflint - performance anti-patterns
+    "PERF", # Perflint — performance anti-patterns
 
     # Security
-    "S",    # flake8-bandit - security issues
+    "S",    # flake8-bandit — security issues
 
     # Testing
-    "PT",   # flake8-pytest-style
+    "PT",   # flake8-pytest-style — consistent pytest idioms
 
     # Error handling
-    "TRY",  # tryceratops - exception handling
-    "LOG",  # flake8-logging - logging best practices
+    "TRY",  # tryceratops — exception handling best practices
+    "LOG",  # flake8-logging — logging best practices
 
-    # Unused code
+    # Housekeeping
     "ARG",  # flake8-unused-arguments
-    "ERA",  # eradicate - commented-out code
-
-    # Print statements (use logging instead)
-    "T20",  # flake8-print
+    "ERA",  # eradicate — commented-out code
+    "T20",  # flake8-print — use logging instead of print()
+]
+ignore = [
+    "TRY003",  # Overly strict — forces custom exception classes for every error message
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -152,7 +156,7 @@ select = [
     "T201",       # CLI output uses print by design
 ]
 "tests/**" = [
-    "S101", "S603", "S607", "S701",  # Allow assert, subprocess, jinja2 in tests
+    "S101", "S404", "S603", "S607",  # Allow assert and subprocess in tests
     "T201",       # Allow print in tests
     "PLR6301",    # Test methods don't use self (pytest classes)
     "PLR2004",    # Magic values in assertions are fine
@@ -239,7 +243,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = "bash scripts/check-template-update.sh"
-update-template = { shell = "copier update --trust . --skip-answered && prek autoupdate && echo '  ✓ Hook versions updated'" }
+update-template = { shell = "copier update --trust . --skip-answered --defaults && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'" }
 
 # GitHub utilities
 # actions-up: https://github.com/azat-io/actions-up

--- a/scripts/check-template-update.sh
+++ b/scripts/check-template-update.sh
@@ -47,9 +47,13 @@ touch "$cache_file"
 
 if [[ "$local_version" != "$latest" ]]; then
   cyan='\033[0;36m'; yellow='\033[1;33m'; dim='\033[2m'; bold='\033[1m'; reset='\033[0m'
-  echo ""
-  echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}"
-  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered"
-  echo -e "  ${dim}Or:${reset}  poe update-template"
-  echo ""
+  # Write to /dev/tty to bypass output capture by hook runners (prek, gt).
+  # Falls back to stdout for non-interactive contexts (CI, scripts, tests).
+  out="/dev/stdout"
+  if (echo -n > /dev/tty) 2>/dev/null; then out="/dev/tty"; fi
+  echo "" > "$out"
+  echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}" > "$out"
+  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered" > "$out"
+  echo -e "  ${dim}Or:${reset}  poe update-template" > "$out"
+  echo "" > "$out"
 fi

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import subprocess  # noqa: S404
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -55,16 +55,16 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "6.1"
+version = "6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
@@ -393,7 +393,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8
 
 [[package]]
 name = "cyclopts"
-version = "4.5.2"
+version = "4.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -401,9 +401,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/cd/1fd03921a95113182e6fdf84af5d47f07aa91c00c03ac074c192b0d4672c/cyclopts-4.5.2.tar.gz", hash = "sha256:7fe01b2d184c55c4555e06a0397602b319d87faa5b086b41913eaeaea52fae16", size = 162381, upload-time = "2026-02-11T16:30:46.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/16/06e35c217334930ff7c476ce1c8e74ed786fa3ef6742e59a1458e2412290/cyclopts-4.5.3.tar.gz", hash = "sha256:35fa70971204c450d9668646a6ca372eb5fa3070fbe8dd51c5b4b31e65198f2d", size = 162437, upload-time = "2026-02-16T15:07:11.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/03/f906829bcfcbb945f19d6a64240ffb66a31d69ca5533e95882f0efc9c13c/cyclopts-4.5.2-py3-none-any.whl", hash = "sha256:ee56ee23c2c81abc34b66b5aa8fd2698ca699740054e84e534449ec3eb7f944d", size = 200165, upload-time = "2026-02-11T16:30:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/1f/d8bce383a90d8a6a11033327777afa4d4d611ec11869284adb6f48152906/cyclopts-4.5.3-py3-none-any.whl", hash = "sha256:50af3085bb15d4a6f2582dd383dad5e4ba6a0d4d4c64ee63326d881a752a6919", size = 200231, upload-time = "2026-02-16T15:07:13.045Z" },
 ]
 
 [[package]]
@@ -1294,15 +1294,15 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.4.2"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/6b/fc3524e6ea04f5a00cb4cc8c09216fcb0fa0546267e07895ba87f8f7ffb2/py_key_value_aio-0.4.2.tar.gz", hash = "sha256:7bbe31d3ce8ee4f7802f34dcc12df23f0a9715c9660b7db34973bb28727dee1b", size = 91129, upload-time = "2026-02-16T02:02:39.796Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/00/e280faf3b15a10eca20a8b68a1cbf1f9b42635a19b350a67ed7db02d3b28/py_key_value_aio-0.4.2-py3-none-any.whl", hash = "sha256:04dd01caec58819834f1256e56e4547da4b4f4fecad8784d5574fa5cba15ff82", size = 150703, upload-time = "2026-02-16T02:02:37.603Z" },
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
 ]
 
 [package.optional-dependencies]
@@ -1932,15 +1932,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Syncs project tooling with copier template v0.29.1. Key changes:

- **Fix `.copier-answers.yml`**: Set `cli_framework: none` (was `typer`, but cyclopts comes transitively from fastmcp)
- **Remove spurious `typer` dep** from `pyproject.toml`
- **Add `ci-pass` aggregation job** in GitHub Actions for cleaner status checks
- **Enhanced ruff config**: clearer rule comments, added `FURB`/`FLY`/`PGH` rules, `S404` in test ignores, `TRY003` globally ignored
- **Improved pre-commit hooks**: pytest `-q` flag, `verbose: true` for better output
- **Template update script**: writes to `/dev/tty` when available to bypass hook runner capture
- Remove unused `# noqa: S404` from `tests/test_gh.py` (now covered by per-file-ignores)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)