### PR TITLE
feat: add install command for one-click MCP client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,38 @@ uv tool install codereviewbuddy
 
 ## MCP Client Configuration
 
-Add the following to your MCP client's config JSON (Windsurf, Claude Desktop, Cursor, VS Code, Claude Code, Gemini CLI, etc. — the JSON shape is the (roughly) same everywhere and I assume you know what your client needs):
+### Quick setup (recommended)
+
+One command configures your MCP client — no manual JSON editing:
+
+```bash
+uvx codereviewbuddy install claude-desktop
+uvx codereviewbuddy install claude-code
+uvx codereviewbuddy install cursor
+uvx codereviewbuddy install windsurf
+uvx codereviewbuddy install windsurf-next
+```
+
+With optional environment variables:
+
+```bash
+uvx codereviewbuddy install windsurf \
+  --env CRB_SELF_IMPROVEMENT__ENABLED=true \
+  --env CRB_SELF_IMPROVEMENT__REPO=your-org/codereviewbuddy
+```
+
+For any other client, generate the JSON config:
+
+```bash
+uvx codereviewbuddy install mcp-json          # print to stdout
+uvx codereviewbuddy install mcp-json --copy   # copy to clipboard
+```
+
+Restart your MCP client after installing. See `uvx codereviewbuddy install --help` for all options.
+
+### Manual configuration
+
+If you prefer manual setup, add the following to your MCP client's config JSON:
 
 ```jsonc
 {

--- a/src/codereviewbuddy/cli.py
+++ b/src/codereviewbuddy/cli.py
@@ -12,6 +12,11 @@ app = cyclopts.App(
     help="codereviewbuddy — AI code review buddy MCP server.",
 )
 
+# Register install subcommand group
+from codereviewbuddy.install import install_app  # noqa: E402
+
+app.command(install_app)
+
 
 @app.default
 def serve() -> None:

--- a/src/codereviewbuddy/install.py
+++ b/src/codereviewbuddy/install.py
@@ -1,0 +1,365 @@
+"""Install codereviewbuddy in MCP clients — one command setup.
+
+Reuses FastMCP's ``StdioMCPServer`` model and ``update_config_file()`` utility
+for config-file clients (Claude Desktop, Windsurf, Windsurf Next), but generates
+a ``uvx``-based command instead of FastMCP's ``uv run ... fastmcp run`` pattern.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import subprocess  # noqa: S404
+import sys
+from pathlib import Path
+from typing import Annotated
+from urllib.parse import quote
+
+import cyclopts
+from fastmcp.mcp_config import StdioMCPServer, update_config_file
+from rich import print as rprint
+
+SERVER_NAME = "codereviewbuddy"
+
+install_app = cyclopts.App(
+    name="install",
+    help="Install codereviewbuddy in an MCP client.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_server_config(
+    env_vars: list[str] | None = None,
+    env_file: Path | None = None,
+) -> StdioMCPServer:
+    """Build the canonical MCP server config for codereviewbuddy."""
+    env: dict[str, str] = {}
+
+    # Load from .env file first (if provided)
+    if env_file:
+        try:
+            from dotenv import dotenv_values  # noqa: PLC0415
+
+            env |= {k: v for k, v in dotenv_values(env_file).items() if v is not None}
+        except Exception as exc:
+            rprint(f"[red]Failed to load .env file: {exc}[/red]")
+            sys.exit(1)
+
+    # CLI --env flags override file values
+    for item in env_vars or []:
+        if "=" not in item:
+            rprint(f"[red]Invalid env var format: '{item}'. Must be KEY=VALUE[/red]")
+            sys.exit(1)
+        key, value = item.split("=", 1)
+        env[key.strip()] = value.strip()
+
+    return StdioMCPServer(
+        command="uvx",
+        args=["--prerelease=allow", "codereviewbuddy@latest"],
+        env=env,
+    )
+
+
+def _write_config_file(
+    config_path: Path,
+    server_config: StdioMCPServer,
+    *,
+    client_name: str,
+) -> bool:
+    """Write server config into an mcpServers JSON file, creating it if needed."""
+    try:
+        # Ensure parent dirs exist
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Create file with empty mcpServers if it doesn't exist or is empty
+        if not config_path.exists() or not config_path.read_text(encoding="utf-8").strip():
+            config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
+
+        update_config_file(config_path, SERVER_NAME, server_config)
+    except Exception as exc:
+        rprint(f"[red]Failed to install in {client_name}: {exc}[/red]")
+        return False
+    else:
+        rprint(f"[green]✅ Successfully installed '{SERVER_NAME}' in {client_name}[/green]")
+        rprint(f"[blue]   Config: {config_path}[/blue]")
+        rprint(f"[blue]   Restart {client_name} to activate.[/blue]")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Config path helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_claude_desktop_config_path() -> Path | None:
+    """Get Claude Desktop config file path (cross-platform)."""
+    if sys.platform == "win32":
+        base = Path.home() / "AppData" / "Roaming" / "Claude"
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support" / "Claude"
+    elif sys.platform.startswith("linux"):
+        base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"), "Claude")
+    else:
+        return None
+
+    if base.exists():
+        return base / "claude_desktop_config.json"
+    return None
+
+
+def _get_windsurf_config_path(variant: str = "windsurf") -> Path:
+    """Get Windsurf/Windsurf Next config file path."""
+    return Path.home() / ".codeium" / variant / "mcp_config.json"
+
+
+# ---------------------------------------------------------------------------
+# Client: Claude Desktop
+# ---------------------------------------------------------------------------
+
+
+@install_app.command(name="claude-desktop")
+def cmd_claude_desktop(
+    *,
+    env: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(name="--env", help="Environment variables in KEY=VALUE format"),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(name=["--env-file", "-f"], help="Load environment variables from .env file"),
+    ] = None,
+) -> None:
+    """Install codereviewbuddy in Claude Desktop."""
+    config_path = _get_claude_desktop_config_path()
+    if config_path is None:
+        rprint(
+            "[red]Claude Desktop config directory not found.[/red]\n"
+            "[blue]Ensure Claude Desktop is installed and has been run at least once.[/blue]"
+        )
+        sys.exit(1)
+
+    server_config = _build_server_config(env_vars=env, env_file=env_file)
+    if not _write_config_file(config_path, server_config, client_name="Claude Desktop"):
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Client: Claude Code
+# ---------------------------------------------------------------------------
+
+
+def _find_claude_command() -> str | None:
+    """Find the Claude Code CLI executable."""
+    claude_in_path = shutil.which("claude")
+    if claude_in_path:
+        try:
+            result = subprocess.run(  # noqa: S603
+                [claude_in_path, "--version"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if "Claude Code" in result.stdout:
+                return claude_in_path
+        except subprocess.CalledProcessError, FileNotFoundError:
+            pass
+
+    potential_paths = [
+        Path.home() / ".claude" / "local" / "claude",
+        Path("/usr/local/bin/claude"),
+        Path.home() / ".npm-global" / "bin" / "claude",
+    ]
+    for path in potential_paths:
+        if path.exists():
+            try:
+                result = subprocess.run(  # noqa: S603
+                    [str(path), "--version"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                if "Claude Code" in result.stdout:
+                    return str(path)
+            except subprocess.CalledProcessError, FileNotFoundError:
+                continue
+    return None
+
+
+@install_app.command(name="claude-code")
+def cmd_claude_code(
+    *,
+    env: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(name="--env", help="Environment variables in KEY=VALUE format"),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(name=["--env-file", "-f"], help="Load environment variables from .env file"),
+    ] = None,
+) -> None:
+    """Install codereviewbuddy in Claude Code."""
+    claude_cmd = _find_claude_command()
+    if not claude_cmd:
+        rprint(
+            "[red]Claude Code CLI not found.[/red]\n[blue]Ensure Claude Code is installed. Try running 'claude --version' to verify.[/blue]"
+        )
+        sys.exit(1)
+
+    server_config = _build_server_config(env_vars=env, env_file=env_file)
+
+    cmd_parts: list[str] = [claude_cmd, "mcp", "add", SERVER_NAME]
+    if server_config.env:
+        for key, value in server_config.env.items():
+            cmd_parts.extend(["-e", f"{key}={value}"])
+    cmd_parts.extend(("--", server_config.command))
+    cmd_parts.extend(server_config.args)
+
+    try:
+        subprocess.run(cmd_parts, check=True, capture_output=True, text=True)  # noqa: S603
+        rprint(f"[green]✅ Successfully installed '{SERVER_NAME}' in Claude Code[/green]")
+    except subprocess.CalledProcessError as exc:
+        rprint(f"[red]Failed to install in Claude Code: {exc.stderr.strip() if exc.stderr else exc}[/red]")
+        sys.exit(1)
+
+
+# ---- Client: Cursor ----
+
+
+def _open_deeplink(url: str) -> bool:
+    """Open a deeplink URL using the system handler."""
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["open", url], check=True, capture_output=True)  # noqa: S603, S607
+        elif sys.platform == "win32":
+            os.startfile(url)  # noqa: S606
+        else:
+            subprocess.run(["xdg-open", url], check=True, capture_output=True)  # noqa: S603, S607
+    except subprocess.CalledProcessError, FileNotFoundError, OSError:
+        return False
+    else:
+        return True
+
+
+@install_app.command(name="cursor")
+def cmd_cursor(
+    *,
+    env: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(name="--env", help="Environment variables in KEY=VALUE format"),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(name=["--env-file", "-f"], help="Load environment variables from .env file"),
+    ] = None,
+) -> None:
+    """Install codereviewbuddy in Cursor (opens deeplink)."""
+    server_config = _build_server_config(env_vars=env, env_file=env_file)
+
+    config_json = server_config.model_dump_json(exclude_none=True)
+    config_b64 = base64.urlsafe_b64encode(config_json.encode()).decode()
+    encoded_name = quote(SERVER_NAME, safe="")
+    deeplink = f"cursor://anysphere.cursor-deeplink/mcp/install?name={encoded_name}&config={config_b64}"
+
+    rprint(f"[blue]Opening Cursor to install '{SERVER_NAME}'...[/blue]")
+    if _open_deeplink(deeplink):
+        rprint("[green]✅ Cursor should now show the installation dialog.[/green]")
+    else:
+        rprint(f"[red]Could not open Cursor automatically.[/red]\n[blue]Copy this link and open it in Cursor:\n{deeplink}[/blue]")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Client: Windsurf / Windsurf Next
+# ---------------------------------------------------------------------------
+
+
+@install_app.command(name="windsurf")
+def cmd_windsurf(
+    *,
+    env: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(name="--env", help="Environment variables in KEY=VALUE format"),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(name=["--env-file", "-f"], help="Load environment variables from .env file"),
+    ] = None,
+) -> None:
+    """Install codereviewbuddy in Windsurf."""
+    config_path = _get_windsurf_config_path("windsurf")
+    server_config = _build_server_config(env_vars=env, env_file=env_file)
+    if not _write_config_file(config_path, server_config, client_name="Windsurf"):
+        sys.exit(1)
+
+
+@install_app.command(name="windsurf-next")
+def cmd_windsurf_next(
+    *,
+    env: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(name="--env", help="Environment variables in KEY=VALUE format"),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(name=["--env-file", "-f"], help="Load environment variables from .env file"),
+    ] = None,
+) -> None:
+    """Install codereviewbuddy in Windsurf Next."""
+    config_path = _get_windsurf_config_path("windsurf-next")
+    server_config = _build_server_config(env_vars=env, env_file=env_file)
+    if not _write_config_file(config_path, server_config, client_name="Windsurf Next"):
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Client: Generic MCP JSON
+# ---------------------------------------------------------------------------
+
+
+@install_app.command(name="mcp-json")
+def cmd_mcp_json(
+    *,
+    env: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(name="--env", help="Environment variables in KEY=VALUE format"),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(name=["--env-file", "-f"], help="Load environment variables from .env file"),
+    ] = None,
+    copy: Annotated[
+        bool,
+        cyclopts.Parameter(name="--copy", help="Copy to clipboard instead of printing to stdout"),
+    ] = False,
+) -> None:
+    """Generate MCP JSON config for any client."""
+    server_config = _build_server_config(env_vars=env, env_file=env_file)
+
+    config_dict: dict[str, object] = {
+        "command": server_config.command,
+        "args": server_config.args,
+    }
+    if server_config.env:
+        config_dict["env"] = server_config.env
+
+    output = json.dumps({SERVER_NAME: config_dict}, indent=2)
+
+    if copy:
+        try:
+            import pyperclip  # noqa: PLC0415
+
+            pyperclip.copy(output)
+            rprint(f"[green]✅ MCP config for '{SERVER_NAME}' copied to clipboard[/green]")
+        except ImportError:
+            rprint("[red]pyperclip not installed. Install with: pip install pyperclip[/red]")
+            rprint(output)
+            sys.exit(1)
+    else:
+        # Print raw JSON to stdout (no rich formatting — for piping)
+        print(output)  # noqa: T201

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,471 @@
+"""Tests for the install CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codereviewbuddy.install import (
+    SERVER_NAME,
+    _build_server_config,
+    _get_claude_desktop_config_path,
+    _get_windsurf_config_path,
+    _write_config_file,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+# ---------------------------------------------------------------------------
+# _build_server_config
+# ---------------------------------------------------------------------------
+
+
+class TestBuildServerConfig:
+    def test_default_config(self):
+        config = _build_server_config()
+        assert config.command == "uvx"
+        assert config.args == ["--prerelease=allow", "codereviewbuddy@latest"]
+        assert config.env == {}
+
+    def test_with_env_vars(self):
+        config = _build_server_config(env_vars=["KEY1=val1", "KEY2=val2"])
+        assert config.env == {"KEY1": "val1", "KEY2": "val2"}
+
+    def test_env_var_with_equals_in_value(self):
+        config = _build_server_config(env_vars=['CRB_REVIEWERS={"a": "b=c"}'])
+        assert config.env["CRB_REVIEWERS"] == '{"a": "b=c"}'
+
+    def test_invalid_env_var_exits(self):
+        with pytest.raises(SystemExit):
+            _build_server_config(env_vars=["NOEQUALS"])
+
+    def test_env_file(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("FROM_FILE=hello\nANOTHER=world\n", encoding="utf-8")
+        config = _build_server_config(env_file=env_file)
+        assert config.env == {"FROM_FILE": "hello", "ANOTHER": "world"}
+
+    def test_env_cli_overrides_file(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=from_file\n", encoding="utf-8")
+        config = _build_server_config(env_vars=["KEY=from_cli"], env_file=env_file)
+        assert config.env["KEY"] == "from_cli"
+
+
+# ---------------------------------------------------------------------------
+# _write_config_file
+# ---------------------------------------------------------------------------
+
+
+class TestWriteConfigFile:
+    def test_creates_new_config(self, tmp_path: Path):
+        config_path = tmp_path / "mcp_config.json"
+        server_config = _build_server_config()
+
+        result = _write_config_file(config_path, server_config, client_name="Test")
+        assert result is True
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert SERVER_NAME in data["mcpServers"]
+        assert data["mcpServers"][SERVER_NAME]["command"] == "uvx"
+
+    def test_preserves_existing_servers(self, tmp_path: Path):
+        config_path = tmp_path / "mcp_config.json"
+        config_path.write_text(
+            json.dumps({
+                "mcpServers": {
+                    "other-server": {"command": "node", "args": ["server.js"]},
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        server_config = _build_server_config()
+        _write_config_file(config_path, server_config, client_name="Test")
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "other-server" in data["mcpServers"]
+        assert SERVER_NAME in data["mcpServers"]
+
+    def test_updates_existing_entry(self, tmp_path: Path):
+        config_path = tmp_path / "mcp_config.json"
+        config_path.write_text(
+            json.dumps({
+                "mcpServers": {
+                    SERVER_NAME: {
+                        "command": "uvx",
+                        "args": ["codereviewbuddy"],
+                        "env": {"OLD_KEY": "old"},
+                    },
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        server_config = _build_server_config(env_vars=["NEW_KEY=new"])
+        _write_config_file(config_path, server_config, client_name="Test")
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        entry = data["mcpServers"][SERVER_NAME]
+        assert entry["args"] == ["--prerelease=allow", "codereviewbuddy@latest"]
+        assert entry["env"]["NEW_KEY"] == "new"
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        config_path = tmp_path / "deep" / "nested" / "mcp_config.json"
+        server_config = _build_server_config()
+
+        result = _write_config_file(config_path, server_config, client_name="Test")
+        assert result is True
+        assert config_path.exists()
+
+    def test_handles_empty_file(self, tmp_path: Path):
+        config_path = tmp_path / "mcp_config.json"
+        config_path.write_text("", encoding="utf-8")
+
+        server_config = _build_server_config()
+        result = _write_config_file(config_path, server_config, client_name="Test")
+        assert result is True
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert SERVER_NAME in data["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# Config path helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPaths:
+    def test_windsurf_path(self):
+        path = _get_windsurf_config_path("windsurf")
+        assert path == Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+
+    def test_windsurf_next_path(self):
+        path = _get_windsurf_config_path("windsurf-next")
+        assert path == Path.home() / ".codeium" / "windsurf-next" / "mcp_config.json"
+
+    @pytest.mark.skipif(
+        __import__("sys").platform != "darwin",
+        reason="macOS-only test",
+    )
+    def test_claude_desktop_path_macos(self):
+        path = _get_claude_desktop_config_path()
+        # Only check the path structure, not existence
+        if path is not None:
+            assert "Claude" in str(path)
+            assert path.name == "claude_desktop_config.json"
+
+
+# ---------------------------------------------------------------------------
+# MCP JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestMcpJsonCommand:
+    def test_json_output(self, capsys):
+        """mcp-json command prints valid JSON to stdout."""
+        from codereviewbuddy.install import cmd_mcp_json
+
+        cmd_mcp_json()
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert SERVER_NAME in data
+        assert data[SERVER_NAME]["command"] == "uvx"
+        assert data[SERVER_NAME]["args"] == ["--prerelease=allow", "codereviewbuddy@latest"]
+
+    def test_json_with_env(self, capsys):
+        from codereviewbuddy.install import cmd_mcp_json
+
+        cmd_mcp_json(env=["CRB_FOO=bar"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data[SERVER_NAME]["env"] == {"CRB_FOO": "bar"}
+
+    def test_json_no_env_key_when_empty(self, capsys):
+        from codereviewbuddy.install import cmd_mcp_json
+
+        cmd_mcp_json()
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "env" not in data[SERVER_NAME]
+
+
+# ---------------------------------------------------------------------------
+# Windsurf commands (filesystem-based — easy to test)
+# ---------------------------------------------------------------------------
+
+
+class TestWindsurfCommands:
+    def test_windsurf_install(self, tmp_path: Path, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.install._get_windsurf_config_path",
+            return_value=tmp_path / "mcp_config.json",
+        )
+        from codereviewbuddy.install import cmd_windsurf
+
+        cmd_windsurf()
+        data = json.loads((tmp_path / "mcp_config.json").read_text(encoding="utf-8"))
+        assert SERVER_NAME in data["mcpServers"]
+
+    def test_windsurf_next_install(self, tmp_path: Path, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.install._get_windsurf_config_path",
+            return_value=tmp_path / "mcp_config.json",
+        )
+        from codereviewbuddy.install import cmd_windsurf_next
+
+        cmd_windsurf_next()
+        data = json.loads((tmp_path / "mcp_config.json").read_text(encoding="utf-8"))
+        assert SERVER_NAME in data["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# Claude Desktop command
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeDesktopCommand:
+    def test_installs_to_config_file(self, tmp_path: Path, mocker: MockerFixture):
+        config_file = tmp_path / "claude_desktop_config.json"
+        config_file.write_text('{"mcpServers": {}}', encoding="utf-8")
+
+        mocker.patch(
+            "codereviewbuddy.install._get_claude_desktop_config_path",
+            return_value=config_file,
+        )
+        from codereviewbuddy.install import cmd_claude_desktop
+
+        cmd_claude_desktop()
+        data = json.loads(config_file.read_text(encoding="utf-8"))
+        assert SERVER_NAME in data["mcpServers"]
+
+    def test_exits_when_config_not_found(self, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.install._get_claude_desktop_config_path",
+            return_value=None,
+        )
+        from codereviewbuddy.install import cmd_claude_desktop
+
+        with pytest.raises(SystemExit):
+            cmd_claude_desktop()
+
+
+# ---------------------------------------------------------------------------
+# Claude Code command
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeCommand:
+    def test_runs_claude_mcp_add(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.install._find_claude_command", return_value="/usr/bin/claude")
+        mock_run = mocker.patch("codereviewbuddy.install.subprocess.run")
+
+        from codereviewbuddy.install import cmd_claude_code
+
+        cmd_claude_code()
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        assert call_args[0] == "/usr/bin/claude"
+        assert call_args[1:3] == ["mcp", "add"]
+        assert SERVER_NAME in call_args
+        assert "uvx" in call_args
+
+    def test_runs_claude_mcp_add_with_env(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.install._find_claude_command", return_value="/usr/bin/claude")
+        mock_run = mocker.patch("codereviewbuddy.install.subprocess.run")
+
+        from codereviewbuddy.install import cmd_claude_code
+
+        cmd_claude_code(env=["CRB_FOO=bar"])
+        call_args = mock_run.call_args[0][0]
+        assert "-e" in call_args
+        assert "CRB_FOO=bar" in call_args
+
+    def test_exits_when_claude_not_found(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.install._find_claude_command", return_value=None)
+        from codereviewbuddy.install import cmd_claude_code
+
+        with pytest.raises(SystemExit):
+            cmd_claude_code()
+
+    def test_exits_on_subprocess_error(self, mocker: MockerFixture):
+        import subprocess
+
+        mocker.patch("codereviewbuddy.install._find_claude_command", return_value="/usr/bin/claude")
+        mocker.patch(
+            "codereviewbuddy.install.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "claude", stderr="fail"),
+        )
+        from codereviewbuddy.install import cmd_claude_code
+
+        with pytest.raises(SystemExit):
+            cmd_claude_code()
+
+
+# ---------------------------------------------------------------------------
+# _find_claude_command
+# ---------------------------------------------------------------------------
+
+
+class TestFindClaudeCommand:
+    def test_found_in_path(self, mocker: MockerFixture):
+        from codereviewbuddy.install import _find_claude_command
+
+        mocker.patch("codereviewbuddy.install.shutil.which", return_value="/usr/bin/claude")
+        mock_run = mocker.patch("codereviewbuddy.install.subprocess.run")
+        mock_run.return_value.stdout = "Claude Code v1.0"
+
+        result = _find_claude_command()
+        assert result == "/usr/bin/claude"
+
+    def test_not_claude_code(self, mocker: MockerFixture):
+        from codereviewbuddy.install import _find_claude_command
+
+        mocker.patch("codereviewbuddy.install.shutil.which", return_value="/usr/bin/claude")
+        mock_run = mocker.patch("codereviewbuddy.install.subprocess.run")
+        mock_run.return_value.stdout = "some other claude"
+
+        # Also mock potential_paths to not exist
+        mocker.patch("pathlib.Path.exists", return_value=False)
+        result = _find_claude_command()
+        assert result is None
+
+    def test_not_in_path_not_in_known_locations(self, mocker: MockerFixture):
+        from codereviewbuddy.install import _find_claude_command
+
+        mocker.patch("codereviewbuddy.install.shutil.which", return_value=None)
+        mocker.patch("pathlib.Path.exists", return_value=False)
+        result = _find_claude_command()
+        assert result is None
+
+    def test_subprocess_error_in_path(self, mocker: MockerFixture):
+        import subprocess
+
+        from codereviewbuddy.install import _find_claude_command
+
+        mocker.patch("codereviewbuddy.install.shutil.which", return_value="/usr/bin/claude")
+        mocker.patch(
+            "codereviewbuddy.install.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "claude"),
+        )
+        mocker.patch("pathlib.Path.exists", return_value=False)
+        result = _find_claude_command()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _open_deeplink
+# ---------------------------------------------------------------------------
+
+
+class TestOpenDeeplink:
+    def test_opens_on_macos(self, mocker: MockerFixture):
+        from codereviewbuddy.install import _open_deeplink
+
+        mocker.patch("codereviewbuddy.install.sys.platform", "darwin")
+        mock_run = mocker.patch("codereviewbuddy.install.subprocess.run")
+        assert _open_deeplink("cursor://test") is True
+        mock_run.assert_called_once()
+
+    def test_opens_on_linux(self, mocker: MockerFixture):
+        from codereviewbuddy.install import _open_deeplink
+
+        mocker.patch("codereviewbuddy.install.sys.platform", "linux")
+        mock_run = mocker.patch("codereviewbuddy.install.subprocess.run")
+        assert _open_deeplink("cursor://test") is True
+        mock_run.assert_called_once()
+
+    def test_returns_false_on_error(self, mocker: MockerFixture):
+        import subprocess
+
+        from codereviewbuddy.install import _open_deeplink
+
+        mocker.patch("codereviewbuddy.install.sys.platform", "darwin")
+        mocker.patch(
+            "codereviewbuddy.install.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "open"),
+        )
+        assert _open_deeplink("cursor://test") is False
+
+
+# ---------------------------------------------------------------------------
+# Cursor command
+# ---------------------------------------------------------------------------
+
+
+class TestCursorCommand:
+    def test_opens_deeplink(self, mocker: MockerFixture):
+        mock_open = mocker.patch("codereviewbuddy.install._open_deeplink", return_value=True)
+        from codereviewbuddy.install import cmd_cursor
+
+        cmd_cursor()
+        mock_open.assert_called_once()
+        url = mock_open.call_args[0][0]
+        assert url.startswith("cursor://")
+        assert SERVER_NAME in url
+
+    def test_exits_on_deeplink_failure(self, mocker: MockerFixture):
+        mocker.patch("codereviewbuddy.install._open_deeplink", return_value=False)
+        from codereviewbuddy.install import cmd_cursor
+
+        with pytest.raises(SystemExit):
+            cmd_cursor()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_write_config_file_returns_false_on_error(self, mocker: MockerFixture, tmp_path: Path):
+        config_path = tmp_path / "mcp_config.json"
+        config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
+
+        server_config = _build_server_config()
+        mocker.patch(
+            "codereviewbuddy.install.update_config_file",
+            side_effect=OSError("disk full"),
+        )
+        result = _write_config_file(config_path, server_config, client_name="Test")
+        assert result is False
+
+    def test_build_server_config_dotenv_error(self, tmp_path: Path, mocker: MockerFixture):
+        env_file = tmp_path / ".env"
+        env_file.write_text("VALID=yes\n", encoding="utf-8")
+
+        mocker.patch(
+            "dotenv.dotenv_values",
+            side_effect=OSError("permission denied"),
+        )
+        with pytest.raises(SystemExit):
+            _build_server_config(env_file=env_file)
+
+    def test_mcp_json_copy_without_pyperclip(self, mocker: MockerFixture):
+        mocker.patch.dict("sys.modules", {"pyperclip": None})
+        from codereviewbuddy.install import cmd_mcp_json
+
+        with pytest.raises(SystemExit):
+            cmd_mcp_json(copy=True)
+
+    def test_claude_desktop_write_failure_exits(self, tmp_path: Path, mocker: MockerFixture):
+        config_file = tmp_path / "claude_desktop_config.json"
+        config_file.write_text('{"mcpServers": {}}', encoding="utf-8")
+
+        mocker.patch(
+            "codereviewbuddy.install._get_claude_desktop_config_path",
+            return_value=config_file,
+        )
+        mocker.patch(
+            "codereviewbuddy.install.update_config_file",
+            side_effect=OSError("disk full"),
+        )
+        from codereviewbuddy.install import cmd_claude_desktop
+
+        with pytest.raises(SystemExit):
+            cmd_claude_desktop()


### PR DESCRIPTION
## Description

Adds a `codereviewbuddy install <client>` CLI command for one-click MCP client registration. Instead of manually editing JSON config files, users can now run a single command.

### Supported clients

| Command | Method |
|---|---|
| `codereviewbuddy install claude-desktop` | Writes to `claude_desktop_config.json` |
| `codereviewbuddy install claude-code` | Runs `claude mcp add` CLI |
| `codereviewbuddy install cursor` | Opens `cursor://` deeplink |
| `codereviewbuddy install windsurf` | Writes to `~/.codeium/windsurf/mcp_config.json` |
| `codereviewbuddy install windsurf-next` | Writes to `~/.codeium/windsurf-next/mcp_config.json` |
| `codereviewbuddy install mcp-json` | Prints JSON config to stdout |

### Features

- Generates `uvx --prerelease=allow codereviewbuddy@latest` as the server command
- `--env KEY=VALUE` flags for environment variables (e.g. reviewer config)
- `--env-file .env` to load env vars from a dotenv file
- `mcp-json --copy` to copy config to clipboard
- Uses FastMCP's `update_config_file()` to safely merge into existing configs

### Files

- **`src/codereviewbuddy/install.py`** — new module with install subcommands
- **`src/codereviewbuddy/cli.py`** — registers `install_app` subcommand group
- **`tests/test_install.py`** — 38 tests covering all clients, env handling, error paths
- **`README.md`** — added "Quick setup" section before manual config instructions

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)