### PR TITLE
build: copier update from template 0.29.2

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.29.1
+_commit: 0.29.2
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: uv run poe setup
@@ -143,6 +144,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         cache-suffix: ${{ matrix.resolution }}
 
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         python-version: "3.14"
         enable-cache: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: uv sync --only-group maintain
@@ -83,6 +84,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.14"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and publish
       run: |

--- a/prek.toml
+++ b/prek.toml
@@ -40,7 +40,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.10.2"  # prek autoupdate will fill this
+rev = "0.10.4"  # prek autoupdate will fill this
 hooks = [{ id = "uv-lock", priority = 1 }]
 
 [[repos]]
@@ -50,12 +50,12 @@ hooks = [{ id = "shellcheck", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
-rev = "v1.7.10"  # prek autoupdate will fill this
+rev = "v1.7.11"  # prek autoupdate will fill this
 hooks = [{ id = "actionlint", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = "v1.43.4"  # prek autoupdate will fill this
+rev = "v1.43.5"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]


### PR DESCRIPTION
## Summary

Copier template update from 0.29.1 → 0.29.2.

## Changes

- **CI/Release workflows**: Added `github-token: ${{ secrets.GITHUB_TOKEN }}` to all `setup-uv` steps (avoids GitHub API rate limits during UV cache operations).
- **Pre-commit hook bumps**: uv `0.10.2` → `0.10.4`, actionlint `v1.7.10` → `v1.7.11`, typos `v1.43.4` → `v1.43.5`.