### PR TITLE
fix: check stderr for Claude Code detection and exclude empty env from deeplink

### DIFF
--- a/src/codereviewbuddy/install.py
+++ b/src/codereviewbuddy/install.py
@@ -170,7 +170,7 @@ def _find_claude_command() -> str | None:
                 capture_output=True,
                 text=True,
             )
-            if "Claude Code" in result.stdout:
+            if "Claude Code" in result.stdout or "Claude Code" in result.stderr:
                 return claude_in_path
         except subprocess.CalledProcessError, FileNotFoundError:
             pass
@@ -189,7 +189,7 @@ def _find_claude_command() -> str | None:
                     capture_output=True,
                     text=True,
                 )
-                if "Claude Code" in result.stdout:
+                if "Claude Code" in result.stdout or "Claude Code" in result.stderr:
                     return str(path)
             except subprocess.CalledProcessError, FileNotFoundError:
                 continue
@@ -266,7 +266,7 @@ def cmd_cursor(
     """Install codereviewbuddy in Cursor (opens deeplink)."""
     server_config = _build_server_config(env_vars=env, env_file=env_file)
 
-    config_json = server_config.model_dump_json(exclude_none=True)
+    config_json = server_config.model_dump_json(exclude_none=True, exclude_defaults=True)
     config_b64 = base64.urlsafe_b64encode(config_json.encode()).decode()
     encoded_name = quote(SERVER_NAME, safe="")
     deeplink = f"cursor://anysphere.cursor-deeplink/mcp/install?name={encoded_name}&config={config_b64}"


### PR DESCRIPTION
## Summary

Address two Greptile review findings from PR #178 (merged before comments were visible due to stacked PR limitations).

## Changes

1. **Check stderr for Claude Code CLI detection** — Some CLI tools (including Node.js-based CLIs) print version info to stderr rather than stdout. `_find_claude_command` now checks both `result.stdout` and `result.stderr` for the "Claude Code" string. Applied to both the PATH lookup and the known-locations fallback.

2. **Exclude empty `env` from Cursor deeplink** — `model_dump_json(exclude_none=True)` still serialized `"env": {}` into the base64 payload when no env vars were provided. Added `exclude_defaults=True` to omit the empty dict, keeping the deeplink payload clean and consistent with `mcp-json` output.

## Tests added

- `test_found_via_stderr` — verifies Claude Code detection when version string is only in stderr
- `test_deeplink_excludes_empty_env` — decodes the base64 deeplink config and asserts `env` key is absent when no env vars provided
- Updated `test_not_claude_code` to also set `stderr=""` for completeness

## Related

Filed #180 for the codereviewbuddy bug where `list_review_comments` missed these inline Greptile threads entirely.