### PR TITLE
feat: add list_recent_unresolved tool to surface comments on merged PRs

### DIFF
--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -114,6 +114,7 @@ class TestToolRegistration:
     EXPECTED_TOOLS = frozenset({
         "list_review_comments",
         "list_stack_review_comments",
+        "list_recent_unresolved",
         "stack_activity",
         "resolve_comment",
         "resolve_stale_comments",
@@ -132,7 +133,7 @@ class TestToolRegistration:
 
     async def test_tool_count(self, client: Client):
         tools = await client.list_tools()
-        assert len(tools) == 11
+        assert len(tools) == 12
 
 
 class TestPromptRegistration:


### PR DESCRIPTION
## Summary

Add a `list_recent_unresolved` MCP tool that scans recently merged PRs for unresolved review threads. Closes #182.

## Problem

When agents review PR stacks, they only discover the current open stack via `gt log`. Reviewers like Greptile that post late-arriving comments on already-merged PRs are invisible — agents miss actionable feedback.

## Solution

New tool: **`list_recent_unresolved`**
- Fetches the N most recently merged PRs via `gh pr list --state merged`
- Reuses existing `_fetch_pr_summary()` (lightweight GraphQL — first comment per thread only)
- Filters to only PRs with unresolved threads (skips clean ones)
- Returns `StackReviewStatusResult` — same format as `summarize_review_status`, zero new models

**Parameters:**
- `repo`: explicit repo or auto-detect
- `limit`: how many merged PRs to scan (default 10, max 50)

## Changes

- `src/codereviewbuddy/tools/stack.py`: `_fetch_merged_prs()` helper + `list_recent_unresolved()` async function
- `src/codereviewbuddy/server.py`: register MCP tool
- `tests/test_stack.py`: 5 new tests
- `tests/test_mcp_integration.py`: update expected tool set + count