### PR TITLE
fix: validate repo format before splitting in all tool functions

### DIFF
--- a/src/codereviewbuddy/gh.py
+++ b/src/codereviewbuddy/gh.py
@@ -287,6 +287,22 @@ def get_current_pr_number(cwd: str | None = None) -> int:
     return int(raw.strip())
 
 
+def parse_repo(repo: str) -> tuple[str, str]:
+    """Parse a repo string in "owner/repo" format into (owner, repo).
+
+    Raises:
+        GhError: If the repo string is not in "owner/repo" format.
+    """
+    if "/" not in repo:
+        msg = f'Invalid repo format: {repo!r}. Expected "owner/repo".'
+        raise GhError(msg)
+    owner, repo_name = repo.split("/", 1)
+    if not owner or not repo_name:
+        msg = f'Invalid repo format: {repo!r}. Expected "owner/repo".'
+        raise GhError(msg)
+    return owner, repo_name
+
+
 def get_repo_info(cwd: str | None = None) -> tuple[str, str]:
     """Get the owner and repo name for the current repository.
 

--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -523,7 +523,7 @@ async def list_review_comments(
         ReviewSummary with threads and per-reviewer statuses.
     """
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = await call_sync_fn_in_threadpool(gh.get_repo_info, cwd=cwd)
 
@@ -836,7 +836,7 @@ def reply_to_comment(
 
     # IC_ and PRR_ paths need owner/repo for the issues comments API
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = gh.get_repo_info(cwd=cwd)
 
@@ -966,7 +966,7 @@ async def triage_review_comments(
     issue_items: list[TriageItem] = []
 
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = await call_sync_fn_in_threadpool(gh.get_repo_info, cwd=cwd)
 

--- a/src/codereviewbuddy/tools/issues.py
+++ b/src/codereviewbuddy/tools/issues.py
@@ -105,7 +105,7 @@ def create_issue_from_comment(  # noqa: PLR0913, PLR0917
         Created issue number, URL, and title.
     """
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = gh.get_repo_info(cwd=cwd)
 

--- a/src/codereviewbuddy/tools/stack.py
+++ b/src/codereviewbuddy/tools/stack.py
@@ -340,7 +340,7 @@ async def summarize_review_status(
         Compact per-PR status with severity counts.
     """
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = await call_sync_fn_in_threadpool(gh.get_repo_info, cwd=cwd)
     full_repo = f"{owner}/{repo_name}"
@@ -445,7 +445,7 @@ async def list_recent_unresolved(
         StackReviewStatusResult containing only PRs that have unresolved threads.
     """
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = await call_sync_fn_in_threadpool(gh.get_repo_info, cwd=cwd)
     full_repo = f"{owner}/{repo_name}"
@@ -593,7 +593,7 @@ async def stack_activity(  # noqa: PLR0914
     from datetime import UTC, datetime  # noqa: PLC0415
 
     if repo:
-        owner, repo_name = repo.split("/", 1)
+        owner, repo_name = gh.parse_repo(repo)
     else:
         owner, repo_name = await call_sync_fn_in_threadpool(gh.get_repo_info, cwd=cwd)
     full_repo = f"{owner}/{repo_name}"

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -21,6 +21,7 @@ from codereviewbuddy.gh import (
     get_current_pr_number,
     get_repo_info,
     graphql,
+    parse_repo,
     rest,
     run_gh,
 )
@@ -286,6 +287,29 @@ class TestGetCurrentPrNumber:
         _patch_run(mocker, stderr="no pull requests found", returncode=1)
         with pytest.raises(GhError, match="no pull requests found"):
             get_current_pr_number()
+
+
+class TestParseRepo:
+    def test_valid_repo(self):
+        owner, repo = parse_repo("detailobsessed/codereviewbuddy")
+        assert owner == "detailobsessed"
+        assert repo == "codereviewbuddy"
+
+    def test_missing_slash_raises(self):
+        with pytest.raises(GhError, match="owner/repo"):
+            parse_repo("myrepo")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(GhError, match="owner/repo"):
+            parse_repo("")
+
+    def test_empty_owner_raises(self):
+        with pytest.raises(GhError, match="owner/repo"):
+            parse_repo("/repo")
+
+    def test_empty_repo_raises(self):
+        with pytest.raises(GhError, match="owner/repo"):
+            parse_repo("owner/")
 
 
 class TestGetRepoInfo:


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->
