### PR TITLE
feat: add diagnose_ci tool for CI failure diagnosis

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -178,6 +178,27 @@ class TriageResult(BaseModel):
     error: str | None = Field(default=None, description="Error message if the request failed")
 
 
+class CIJobFailure(BaseModel):
+    """A single failed job in a CI workflow run."""
+
+    job_name: str = Field(description="Name of the failed job")
+    conclusion: str = Field(description="Job conclusion (e.g. 'failure', 'cancelled')")
+    failed_step: str = Field(default="", description="Name of the first failed step within the job")
+    error_lines: list[str] = Field(default_factory=list, description="Extracted error/failure lines from the job logs")
+
+
+class CIDiagnosisResult(BaseModel):
+    """Structured CI failure diagnosis from a GitHub Actions workflow run."""
+
+    run_id: int = Field(default=0, description="Workflow run ID")
+    workflow: str = Field(default="", description="Workflow name (e.g. 'ci', 'release')")
+    branch: str = Field(default="", description="Branch the run was triggered on")
+    conclusion: str = Field(default="", description="Overall run conclusion (e.g. 'failure')")
+    url: str = Field(default="", description="URL to the workflow run")
+    failures: list[CIJobFailure] = Field(default_factory=list, description="Failed jobs with extracted error details")
+    error: str | None = Field(default=None, description="Error message if diagnosis itself failed")
+
+
 class ConfigInfo(BaseModel):
     """Active codereviewbuddy configuration with metadata."""
 

--- a/src/codereviewbuddy/tools/ci.py
+++ b/src/codereviewbuddy/tools/ci.py
@@ -1,0 +1,269 @@
+"""CI diagnosis — find and surface GitHub Actions failures."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from codereviewbuddy import gh
+from codereviewbuddy.models import CIDiagnosisResult, CIJobFailure
+
+if TYPE_CHECKING:
+    from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Lines matching these patterns are noise — strip them from error output.
+_NOISE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^##\[(end)?group\]"),
+    re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*$"),
+    re.compile(r"^(Post job cleanup|Cleaning up orphan processes)"),
+    re.compile(r"^\s*shell:\s+/"),
+    re.compile(r"^\s*env:\s*$"),
+    re.compile(r"^\s+\w+:.*$"),  # indented env var lines
+]
+
+# Lines matching these patterns are interesting — keep them.
+_ERROR_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"##\[error\]", re.IGNORECASE),
+    re.compile(r"\berrors?\b", re.IGNORECASE),
+    re.compile(r"\bFailed\b", re.IGNORECASE),
+    re.compile(r"\bfailure\b", re.IGNORECASE),
+    re.compile(r"\bfatal\b", re.IGNORECASE),
+    re.compile(r"\bERROR:", re.IGNORECASE),
+    re.compile(r"\bTraceback\b"),
+    re.compile(r"\bAssertionError\b"),
+    re.compile(r"\bexception\b", re.IGNORECASE),
+    re.compile(r"exit code [1-9]"),
+    re.compile(r"Process completed with exit code [1-9]"),
+]
+
+_MAX_ERROR_LINES = 50
+_MAX_LOG_LINES = 2000
+
+
+def _is_noise(line: str) -> bool:
+    """Return True if the line is CI log noise."""
+    return any(p.search(line) for p in _NOISE_PATTERNS)
+
+
+def _is_error_line(line: str) -> bool:
+    """Return True if the line looks like an error."""
+    return any(p.search(line) for p in _ERROR_PATTERNS)
+
+
+def _strip_timestamp(line: str) -> str:
+    """Remove the leading ISO timestamp from a log line if present."""
+    return re.sub(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*", "", line)
+
+
+def _strip_job_prefix(line: str) -> str:
+    """Remove the leading job-name prefix (e.g. 'prek    UNKNOWN STEP    ')."""
+    return re.sub(r"^\S+\s+\S+\s+\S+\s+", "", line)
+
+
+def _clean_log_line(line: str) -> str:
+    """Strip noise prefixes from a raw gh log line."""
+    cleaned = _strip_job_prefix(line)
+    cleaned = _strip_timestamp(cleaned)
+    return cleaned.rstrip()
+
+
+def _extract_error_lines(raw_log: str) -> list[str]:
+    """Extract actionable error lines from raw gh log output.
+
+    Keeps lines that match error patterns, strips noise, and adds a few
+    lines of context around each error for readability.
+    """
+    lines = raw_log.splitlines()
+    if len(lines) > _MAX_LOG_LINES:
+        lines = lines[-_MAX_LOG_LINES:]
+
+    cleaned = [_clean_log_line(line) for line in lines]
+
+    # Find indices of error lines
+    error_indices: set[int] = set()
+    for i, line in enumerate(cleaned):
+        if _is_error_line(line) and not _is_noise(line):
+            # Add the error line plus 2 lines of context before and after
+            error_indices.update(range(max(0, i - 2), min(len(cleaned), i + 3)))
+
+    result: list[str] = []
+    prev_idx = -2
+    for idx in sorted(error_indices):
+        line = cleaned[idx]
+        if not line or _is_noise(line):
+            continue
+        # Insert a separator when there's a gap
+        if idx > prev_idx + 1 and result:
+            result.append("---")
+        result.append(line)
+        prev_idx = idx
+
+    return result[:_MAX_ERROR_LINES]
+
+
+def _find_latest_failed_run(
+    *,
+    pr_number: int | None = None,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict[str, Any] | None:
+    """Find the latest failed workflow run for a branch or PR."""
+    args = [
+        "run",
+        "list",
+        "--json",
+        "databaseId,status,conclusion,name,headBranch,url",
+        "--limit",
+        "20",
+    ]
+    if repo:
+        args.extend(["--repo", repo])
+
+    # If we have a PR number, get the branch name first
+    if pr_number is not None:
+        pr_args = ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
+        if repo:
+            pr_args.extend(["--repo", repo])
+        branch = gh.run_gh(*pr_args, cwd=cwd).strip()
+        args.extend(["--branch", branch])
+
+    raw = gh.run_gh(*args, cwd=cwd)
+    runs: list[dict[str, Any]] = json.loads(raw)
+
+    # Find the first completed failure
+    for run in runs:
+        if run.get("status") == "completed" and run.get("conclusion") == "failure":
+            return run
+    return None
+
+
+def _get_run_details(
+    run_id: int,
+    *,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict[str, Any]:
+    """Get detailed info about a workflow run including jobs."""
+    args = ["run", "view", str(run_id), "--json", "jobs,name,headBranch,conclusion,url"]
+    if repo:
+        args.extend(["--repo", repo])
+    raw = gh.run_gh(*args, cwd=cwd)
+    return json.loads(raw)
+
+
+def _get_failed_logs(
+    run_id: int,
+    *,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> str:
+    """Get the failed job logs for a workflow run."""
+    args = ["run", "view", str(run_id), "--log-failed"]
+    if repo:
+        args.extend(["--repo", repo])
+    return gh.run_gh(*args, cwd=cwd)
+
+
+def diagnose_ci(
+    *,
+    pr_number: int | None = None,
+    repo: str | None = None,
+    run_id: int | None = None,
+    cwd: str | None = None,
+) -> CIDiagnosisResult:
+    """Diagnose CI failures for a PR or specific workflow run.
+
+    This collapses the typical 3-5 sequential ``gh`` commands into one call:
+    1. Find the latest failed run (or use a specific run_id)
+    2. Identify failed jobs and steps
+    3. Extract actionable error lines from logs
+    """
+    # Step 1: Find the run
+    if run_id is not None:
+        run_info: dict[str, Any] | None = {"databaseId": run_id}
+    else:
+        run_info = _find_latest_failed_run(pr_number=pr_number, repo=repo, cwd=cwd)
+
+    if run_info is None:
+        return CIDiagnosisResult(error="No failed workflow runs found.")
+
+    actual_run_id = run_info["databaseId"]
+
+    # Step 2: Get run details with jobs
+    try:
+        details = _get_run_details(actual_run_id, repo=repo, cwd=cwd)
+    except gh.GhError as exc:
+        return CIDiagnosisResult(
+            run_id=actual_run_id,
+            error=f"Failed to fetch run details: {exc}",
+        )
+
+    workflow = details.get("name", "")
+    branch = details.get("headBranch", run_info.get("headBranch", ""))
+    conclusion = details.get("conclusion", run_info.get("conclusion", ""))
+    url = details.get("url", run_info.get("url", ""))
+
+    # Step 3: Identify failed jobs
+    jobs = details.get("jobs", [])
+    failed_jobs = [j for j in jobs if j.get("conclusion") == "failure"]
+
+    if not failed_jobs:
+        return CIDiagnosisResult(
+            run_id=actual_run_id,
+            workflow=workflow,
+            branch=branch,
+            conclusion=conclusion,
+            url=url,
+            error="Run marked as failure but no individual jobs failed.",
+        )
+
+    # Step 4: Get failed logs and extract errors
+    try:
+        raw_logs = _get_failed_logs(actual_run_id, repo=repo, cwd=cwd)
+    except gh.GhError as exc:
+        logger.warning("Failed to fetch logs for run %d: %s", actual_run_id, exc)
+        raw_logs = ""
+
+    error_lines = _extract_error_lines(raw_logs) if raw_logs else []
+
+    return CIDiagnosisResult(
+        run_id=actual_run_id,
+        workflow=workflow,
+        branch=branch,
+        conclusion=conclusion,
+        url=url,
+        failures=_build_failures(failed_jobs, error_lines),
+    )
+
+
+def _build_failures(
+    failed_jobs: list[dict[str, Any]],
+    error_lines: list[str],
+) -> list[CIJobFailure]:
+    """Convert raw job dicts into CIJobFailure models with matched error lines."""
+    failures: list[CIJobFailure] = []
+    for job in failed_jobs:
+        job_name = job.get("name", "unknown")
+        failed_step = next(
+            (s.get("name", "") for s in job.get("steps", []) if s.get("conclusion") == "failure"),
+            "",
+        )
+        # For multi-job failures, try to match errors to the specific job
+        if len(failed_jobs) > 1:
+            job_errors = [line for line in error_lines if job_name.lower() in line.lower()] or error_lines
+        else:
+            job_errors = error_lines
+
+        failures.append(
+            CIJobFailure(
+                job_name=job_name,
+                conclusion=job.get("conclusion", "failure"),
+                failed_step=failed_step,
+                error_lines=job_errors,
+            )
+        )
+    return failures

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,0 +1,223 @@
+"""Tests for CI diagnosis tool."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from codereviewbuddy.gh import GhError
+from codereviewbuddy.tools.ci import (
+    _clean_log_line,
+    _extract_error_lines,
+    _is_error_line,
+    _is_noise,
+    diagnose_ci,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUN_LIST_SUCCESS = json.dumps([
+    {
+        "databaseId": 111,
+        "status": "completed",
+        "conclusion": "success",
+        "name": "ci",
+        "headBranch": "main",
+        "url": "https://github.com/org/repo/actions/runs/111",
+    },
+])
+
+_RUN_LIST_FAILURE = json.dumps([
+    {
+        "databaseId": 222,
+        "status": "completed",
+        "conclusion": "failure",
+        "name": "ci",
+        "headBranch": "feat-branch",
+        "url": "https://github.com/org/repo/actions/runs/222",
+    },
+])
+
+_RUN_DETAILS = json.dumps({
+    "name": "ci",
+    "headBranch": "feat-branch",
+    "conclusion": "failure",
+    "url": "https://github.com/org/repo/actions/runs/222",
+    "jobs": [
+        {
+            "name": "test",
+            "conclusion": "success",
+            "steps": [],
+        },
+        {
+            "name": "lint",
+            "conclusion": "failure",
+            "steps": [
+                {"name": "Checkout", "conclusion": "success"},
+                {"name": "Run ruff", "conclusion": "failure"},
+            ],
+        },
+    ],
+})
+
+_RUN_DETAILS_NO_FAILED_JOBS = json.dumps({
+    "name": "ci",
+    "headBranch": "feat-branch",
+    "conclusion": "failure",
+    "url": "https://github.com/org/repo/actions/runs/222",
+    "jobs": [
+        {"name": "test", "conclusion": "success", "steps": []},
+    ],
+})
+
+_FAILED_LOGS = """\
+lint    UNKNOWN STEP    2026-02-19T08:30:36.3494085Z ##[group]Run ruff
+lint    UNKNOWN STEP    2026-02-19T08:30:36.6504054Z src/app.py:10:1: E302 expected 2 blank lines
+lint    UNKNOWN STEP    2026-02-19T08:30:36.6505056Z src/app.py:25:80: E501 line too long
+lint    UNKNOWN STEP    2026-02-19T08:30:36.6506191Z Found 2 errors.
+lint    UNKNOWN STEP    2026-02-19T08:33:36.6946723Z ##[error]Process completed with exit code 1.
+lint    UNKNOWN STEP    2026-02-19T08:33:36.7034513Z Post job cleanup.
+lint    UNKNOWN STEP    2026-02-19T08:33:36.8301351Z Cleaning up orphan processes
+"""
+
+
+def _mock_gh(mocker: MockerFixture, side_effects: list[str]) -> None:
+    """Mock gh.run_gh to return successive values."""
+    mocker.patch("codereviewbuddy.tools.ci.gh.run_gh", side_effect=side_effects)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsNoise:
+    def test_group_markers(self):
+        assert _is_noise("##[group]Run ruff")
+        assert _is_noise("##[endgroup]")
+
+    def test_post_job_cleanup(self):
+        assert _is_noise("Post job cleanup.")
+
+    def test_cleaning_up(self):
+        assert _is_noise("Cleaning up orphan processes")
+
+    def test_shell_line(self):
+        assert _is_noise("  shell: /usr/bin/bash --noprofile")
+
+    def test_normal_line(self):
+        assert not _is_noise("src/app.py:10:1: E302 expected 2 blank lines")
+
+
+class TestIsErrorLine:
+    def test_github_error_annotation(self):
+        assert _is_error_line("##[error]Process completed with exit code 1.")
+
+    def test_error_word(self):
+        assert _is_error_line("Found 2 errors.")
+
+    def test_failed_word(self):
+        assert _is_error_line("Tests Failed")
+
+    def test_exit_code(self):
+        assert _is_error_line("exit code 1")
+
+    def test_normal_line(self):
+        assert not _is_error_line("All checks passed")
+
+
+class TestCleanLogLine:
+    def test_strips_job_prefix_and_timestamp(self):
+        raw = "lint    UNKNOWN STEP    2026-02-19T08:30:36.6504054Z src/app.py:10:1: E302"
+        assert _clean_log_line(raw) == "src/app.py:10:1: E302"
+
+    def test_plain_line(self):
+        assert _clean_log_line("hello world") == "hello world"
+
+
+class TestExtractErrorLines:
+    def test_extracts_errors_from_logs(self):
+        lines = _extract_error_lines(_FAILED_LOGS)
+        assert len(lines) > 0
+        assert any("error" in line.lower() or "Error" in line for line in lines)
+
+    def test_empty_logs(self):
+        assert _extract_error_lines("") == []
+
+    def test_no_errors(self):
+        assert _extract_error_lines("All checks passed\nDone\n") == []
+
+    def test_strips_noise(self):
+        lines = _extract_error_lines(_FAILED_LOGS)
+        for line in lines:
+            if line == "---":
+                continue
+            assert not _is_noise(line)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for diagnose_ci
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseCI:
+    def test_no_failed_runs(self, mocker: MockerFixture):
+        _mock_gh(mocker, [_RUN_LIST_SUCCESS])
+        result = diagnose_ci(repo="org/repo")
+        assert result.error == "No failed workflow runs found."
+
+    def test_finds_and_diagnoses_failure(self, mocker: MockerFixture):
+        _mock_gh(mocker, [_RUN_LIST_FAILURE, _RUN_DETAILS, _FAILED_LOGS])
+        result = diagnose_ci(repo="org/repo")
+        assert result.run_id == 222
+        assert result.workflow == "ci"
+        assert result.branch == "feat-branch"
+        assert result.conclusion == "failure"
+        assert len(result.failures) == 1
+        assert result.failures[0].job_name == "lint"
+        assert result.failures[0].failed_step == "Run ruff"
+        assert len(result.failures[0].error_lines) > 0
+        assert result.error is None
+
+    def test_specific_run_id(self, mocker: MockerFixture):
+        _mock_gh(mocker, [_RUN_DETAILS, _FAILED_LOGS])
+        result = diagnose_ci(run_id=222, repo="org/repo")
+        assert result.run_id == 222
+        assert result.failures[0].job_name == "lint"
+
+    def test_pr_number_resolves_branch(self, mocker: MockerFixture):
+        _mock_gh(mocker, ["feat-branch\n", _RUN_LIST_FAILURE, _RUN_DETAILS, _FAILED_LOGS])
+        result = diagnose_ci(pr_number=42, repo="org/repo")
+        assert result.run_id == 222
+
+    def test_no_failed_jobs_in_run(self, mocker: MockerFixture):
+        _mock_gh(mocker, [_RUN_LIST_FAILURE, _RUN_DETAILS_NO_FAILED_JOBS])
+        result = diagnose_ci(repo="org/repo")
+        assert result.error is not None
+        assert "no individual jobs failed" in result.error.lower()
+
+    def test_run_details_gh_error(self, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.tools.ci.gh.run_gh",
+            side_effect=[_RUN_LIST_FAILURE, GhError("API rate limited")],
+        )
+        result = diagnose_ci(repo="org/repo")
+        assert result.run_id == 222
+        assert result.error is not None
+        assert "rate limited" in result.error.lower()
+
+    def test_log_fetch_fails_gracefully(self, mocker: MockerFixture):
+        mocker.patch(
+            "codereviewbuddy.tools.ci.gh.run_gh",
+            side_effect=[_RUN_LIST_FAILURE, _RUN_DETAILS, GhError("log fetch failed")],
+        )
+        result = diagnose_ci(repo="org/repo")
+        assert result.run_id == 222
+        assert len(result.failures) == 1
+        assert result.failures[0].error_lines == []
+        assert result.error is None

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -112,6 +112,7 @@ async def client(mocker: MockerFixture):
 
 class TestToolRegistration:
     EXPECTED_TOOLS = frozenset({
+        "diagnose_ci",
         "list_review_comments",
         "list_stack_review_comments",
         "list_recent_unresolved",
@@ -133,7 +134,7 @@ class TestToolRegistration:
 
     async def test_tool_count(self, client: Client):
         tools = await client.list_tools()
-        assert len(tools) == 12
+        assert len(tools) == 13
 
 
 class TestPromptRegistration:


### PR DESCRIPTION
## Description

Add a new `diagnose_ci` MCP tool that lets agents quickly diagnose GitHub Actions CI failures in a single call, replacing the typical 3-5 sequential `gh` commands.

### Problem
Agents currently need to run multiple `gh` commands to diagnose CI failures:
1. `gh run list` → find failed runs
2. `gh run view <id> --json jobs` → find failed jobs
3. `gh run view <id> --log-failed` → get error logs
4. Manually parse noisy log output to find actual errors

### Solution
The `diagnose_ci` tool collapses this into one call that returns structured results:
- Finds the latest failed run for a PR/branch (or accepts a specific `run_id`)
- Identifies failed jobs and the specific failed step within each
- Extracts actionable error lines from logs, filtering out CI noise (timestamps, group markers, cleanup steps)

### New files
- `src/codereviewbuddy/tools/ci.py` — business logic (`diagnose_ci`, log parsing, error extraction)
- `tests/test_ci.py` — 23 tests covering helpers and integration scenarios

### Changes to existing files
- `src/codereviewbuddy/models.py` — add `CIJobFailure` and `CIDiagnosisResult` models
- `src/codereviewbuddy/server.py` — register `diagnose_ci` tool with prerequisite validation
- `tests/test_mcp_integration.py` — add `diagnose_ci` to expected tools set, bump count to 13

### Bug fix included
Fixed prerequisite validation: when `run_id` is provided without `repo` and no workspace is detected, the tool now correctly requires `repo` to be provided (previously skipped the check entirely).

## Checklist

- [x] Tests added/updated
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)