### PR TITLE
feat: migrate tools to github_api httpx client, fix async tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=3.0.0",
+    "httpx>=0.28",
     "pydantic-settings>=2.0",
 ]
 
@@ -51,6 +52,7 @@ ci = [
     "pytest>=8",
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
+    "respx>=0.22",
     "ty>=0.0.14",
     "poethepoet>=0.41",
     "pytest-asyncio>=1.3.0",

--- a/src/codereviewbuddy/github_api.py
+++ b/src/codereviewbuddy/github_api.py
@@ -1,0 +1,360 @@
+"""Direct GitHub API client using httpx with PAT authentication.
+
+Authentication priority (resolved once at startup, then cached):
+1. ``GH_TOKEN`` env var
+2. ``GITHUB_TOKEN`` env var
+3. ``gh auth token`` subprocess — reads local ``~/.config/gh/hosts.yml``, no network
+4. Raises :exc:`GitHubAuthError` with setup URL
+
+New users: https://github.com/settings/tokens/new?scopes=repo&description=codereviewbuddy
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import subprocess  # noqa: S404
+from typing import Any
+
+import httpx
+
+from codereviewbuddy import cache
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API_URL = "https://api.github.com"
+_GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+TOKEN_CREATE_URL = "https://github.com/settings/tokens/new?scopes=repo&description=codereviewbuddy"  # noqa: S105
+
+_token: str | None = None
+_token_resolved: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+class GitHubError(Exception):
+    """Raised when a GitHub API call fails."""
+
+    def __init__(self, message: str, status_code: int = 0) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class GitHubAuthError(GitHubError):
+    """Raised when GitHub authentication fails or no token is available."""
+
+    def __init__(self, detail: str = "") -> None:
+        msg = (
+            "GitHub token not found. "
+            "Set GH_TOKEN or GITHUB_TOKEN env var, or run 'gh auth login'.\n"
+            f"Create a token (permissions pre-filled): {TOKEN_CREATE_URL}"
+        )
+        if detail:
+            msg = f"{detail}\n{msg}"
+        super().__init__(msg, status_code=401)
+
+
+# ---------------------------------------------------------------------------
+# Repo parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_repo(repo: str) -> tuple[str, str]:
+    """Parse an ``owner/repo`` string into a ``(owner, repo_name)`` tuple.
+
+    Raises:
+        GitHubError: If the string is not in ``owner/repo`` format.
+    """
+    owner, _, repo_name = repo.partition("/")
+    if not repo_name:
+        msg = f"Invalid repo format {repo!r}. Expected 'owner/repo'."
+        raise GitHubError(msg)
+    return owner, repo_name
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token_sync() -> str | None:
+    """Resolve GitHub token synchronously. Safe to run in a thread.
+
+    Tries (in order):
+    1. ``GH_TOKEN`` env var
+    2. ``GITHUB_TOKEN`` env var
+    3. ``gh auth token`` — reads local ``~/.config/gh/hosts.yml``, no network
+    """
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        logger.debug("GitHub token resolved from env var")
+        return token
+
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            logger.debug("GitHub token resolved from gh auth token")
+            return result.stdout.strip()
+    except FileNotFoundError, subprocess.TimeoutExpired, OSError:
+        pass
+
+    return None
+
+
+async def get_token() -> str:
+    """Return the GitHub token, resolving it lazily on first call.
+
+    Raises:
+        GitHubAuthError: If no token can be found.
+    """
+    global _token, _token_resolved  # noqa: PLW0603
+    if not _token_resolved:
+        _token = await asyncio.to_thread(_resolve_token_sync)
+        _token_resolved = True
+    if _token is None:
+        raise GitHubAuthError
+    return _token
+
+
+def reset_token() -> None:
+    """Reset cached token (for testing)."""
+    global _token, _token_resolved  # noqa: PLW0603
+    _token = None
+    _token_resolved = False
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_headers() -> dict[str, str]:
+    """Build GitHub API request headers with resolved auth token."""
+    token = await get_token()
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+_HTTP_UNAUTHORIZED = 401
+_HTTP_FORBIDDEN = 403
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    """Raise appropriate :exc:`GitHubError` subclass for non-2xx responses."""
+    if response.is_success:
+        return
+
+    if response.status_code == _HTTP_UNAUTHORIZED:
+        raise GitHubAuthError
+
+    try:
+        body = response.json()
+        msg = body.get("message", response.text)
+    except Exception:
+        msg = response.text
+
+    if response.status_code == _HTTP_FORBIDDEN:
+        if "rate limit" in msg.lower():
+            msg = f"GitHub API rate limit exceeded: {msg}"
+            raise GitHubError(msg, status_code=_HTTP_FORBIDDEN)
+        msg = f"GitHub API access forbidden: {msg}"
+        raise GitHubAuthError(msg)
+
+    msg = f"GitHub API error {response.status_code}: {msg}"
+    raise GitHubError(msg, status_code=response.status_code)
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    """Parse a ``Link:`` header and return the ``next`` URL if present."""
+    if not link_header:
+        return None
+    match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# GraphQL
+# ---------------------------------------------------------------------------
+
+
+async def graphql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Execute a GitHub GraphQL query or mutation.
+
+    Queries are cached with a short TTL. Mutations bypass and invalidate the cache.
+
+    Args:
+        query: GraphQL query or mutation string.
+        variables: Optional variables dict.
+
+    Returns:
+        Parsed JSON response dict (full envelope including ``data``).
+
+    Raises:
+        GitHubError: On GraphQL errors or HTTP failure.
+        GitHubAuthError: On authentication failure.
+    """
+    is_mutation = query.strip().lower().startswith("mutation")
+
+    if not is_mutation:
+        key = cache.make_key("graphql", query, variables)
+        cached = cache.get(key)
+        if cached is not cache._SENTINEL:
+            return cached  # type: ignore[return-value]
+
+    headers = await _get_headers()
+    payload: dict[str, Any] = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    logger.debug("GraphQL %s", "mutation" if is_mutation else "query")
+    async with httpx.AsyncClient() as client:
+        response = await client.post(_GITHUB_GRAPHQL_URL, headers=headers, json=payload)
+
+    _raise_for_status(response)
+    result: dict[str, Any] = response.json()
+
+    errors = result.get("errors")
+    if errors:
+        messages = "; ".join(e.get("message", str(e)) for e in errors)
+        msg = f"GraphQL error: {messages}"
+        raise GitHubError(msg)
+
+    if is_mutation:
+        cache.clear()
+    else:
+        cache.put(key, result)  # type: ignore[possibly-undefined]
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# REST
+# ---------------------------------------------------------------------------
+
+
+async def rest(
+    endpoint: str,
+    method: str = "GET",
+    *,
+    paginate: bool = False,
+    **kwargs: Any,
+) -> Any:
+    """Execute a GitHub REST API call.
+
+    GET requests are cached. Non-GET requests bypass and invalidate the cache.
+
+    Args:
+        endpoint: REST API endpoint path (e.g. ``/repos/owner/repo/pulls``).
+            Query parameters may be embedded directly in the path.
+        method: HTTP method (default ``GET``).
+        paginate: If ``True``, follow ``Link:`` headers to collect all pages.
+            Returns a flat list combining all page results.
+        **kwargs: Additional query parameters (GET) or JSON body fields (non-GET).
+
+    Returns:
+        Parsed JSON response, or a flat list when ``paginate=True``.
+
+    Raises:
+        GitHubError: On HTTP failure.
+        GitHubAuthError: On authentication failure.
+    """
+    is_read = method.upper() == "GET"
+
+    if is_read:
+        key = cache.make_key("rest", endpoint, method, paginate, kwargs)
+        cached = cache.get(key)
+        if cached is not cache._SENTINEL:
+            return cached
+
+    url = f"{_GITHUB_API_URL}{endpoint}"
+    headers = await _get_headers()
+
+    if paginate:
+        result = await _paginate_rest(url, headers, **kwargs)
+    else:
+        result = await _single_rest(url, method, headers, **kwargs)
+
+    if is_read:
+        cache.put(key, result)  # type: ignore[possibly-undefined]
+    else:
+        cache.clear()
+
+    return result
+
+
+async def _single_rest(url: str, method: str, headers: dict[str, str], **kwargs: Any) -> Any:
+    """Make a single REST request and return parsed JSON."""
+    upper = method.upper()
+    params = dict(kwargs) if upper == "GET" and kwargs else None
+    json_body = dict(kwargs) if upper != "GET" and kwargs else None
+
+    async with httpx.AsyncClient() as client:
+        response = await client.request(method, url, headers=headers, params=params, json=json_body)
+
+    _raise_for_status(response)
+    if not response.content:
+        return None
+    return response.json()
+
+
+async def _paginate_rest(url: str, headers: dict[str, str], **kwargs: Any) -> list[Any]:
+    """Follow ``Link:`` headers to collect all pages into a flat list."""
+    results: list[Any] = []
+    next_url: str | None = url
+    first = True
+
+    async with httpx.AsyncClient() as client:
+        while next_url:
+            params = dict(kwargs) if first and kwargs else None
+            response = await client.get(next_url, headers=headers, params=params)
+            _raise_for_status(response)
+            page = response.json()
+            if isinstance(page, list):
+                results.extend(page)
+            elif page is not None:
+                results.append(page)
+            next_url = _parse_next_link(response.headers.get("link", ""))
+            first = False
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Binary downloads
+# ---------------------------------------------------------------------------
+
+
+async def download_bytes(url: str) -> bytes:
+    """Download raw bytes from a URL, following redirects.
+
+    Used for GitHub Actions log zip downloads.
+
+    Args:
+        url: The URL to download from (may redirect).
+
+    Returns:
+        Raw response bytes.
+
+    Raises:
+        GitHubError: On HTTP failure.
+        GitHubAuthError: On authentication failure.
+    """
+    headers = await _get_headers()
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        response = await client.get(url, headers=headers)
+    _raise_for_status(response)
+    return response.content

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -448,7 +448,7 @@ async def resolve_comment(
         cwd = await _get_workspace_cwd(ctx)
         _check_auto_detect_prerequisites(cwd, has_pr=pr_number is not None, has_repo=True)
         pr_number = _resolve_pr_number(pr_number, cwd=cwd)
-        return comments.resolve_comment(pr_number, thread_id, cwd=cwd)
+        return await comments.resolve_comment(pr_number, thread_id, cwd=cwd)
     except Exception as exc:
         logger.exception("resolve_comment failed for %s on PR #%s", thread_id, pr_number)
         return _recovery_error(exc, tool_name="resolve_comment", pr_number=pr_number)
@@ -512,7 +512,7 @@ async def reply_to_comment(
         cwd = await _get_workspace_cwd(ctx)
         _check_auto_detect_prerequisites(cwd, has_pr=pr_number is not None, has_repo=repo is not None)
         pr_number = _resolve_pr_number(pr_number, cwd=cwd)
-        return comments.reply_to_comment(pr_number, thread_id, body, repo=repo, cwd=cwd)
+        return await comments.reply_to_comment(pr_number, thread_id, body, repo=repo, cwd=cwd)
     except Exception as exc:
         logger.exception("reply_to_comment failed for %s on PR #%s", thread_id, pr_number)
         return _recovery_error(exc, tool_name="reply_to_comment", pr_number=pr_number, repo=repo)
@@ -546,7 +546,7 @@ async def create_issue_from_comment(
         cwd = await _get_workspace_cwd(ctx)
         _check_auto_detect_prerequisites(cwd, has_pr=pr_number is not None, has_repo=repo is not None)
         pr_number = _resolve_pr_number(pr_number, cwd=cwd)
-        return issues.create_issue_from_comment(
+        return await issues.create_issue_from_comment(
             pr_number,
             thread_id,
             title,

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,371 @@
+"""Tests for the github_api module (httpx-based GitHub client)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import respx
+from httpx import Response
+
+from codereviewbuddy.github_api import (
+    _HTTP_FORBIDDEN,
+    _HTTP_UNAUTHORIZED,
+    GitHubAuthError,
+    GitHubError,
+    _parse_next_link,
+    _raise_for_status,
+    _resolve_token_sync,
+    download_bytes,
+    graphql,
+    parse_repo,
+    reset_token,
+    rest,
+)
+
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAuthError:
+    def test_default_message_contains_setup_url(self):
+        err = GitHubAuthError()
+        assert "GH_TOKEN" in str(err)
+        assert "github.com/settings/tokens" in str(err)
+
+    def test_detail_prepended(self):
+        err = GitHubAuthError("Access denied")
+        assert str(err).startswith("Access denied")
+        assert "GH_TOKEN" in str(err)
+
+    def test_status_code_is_401(self):
+        assert GitHubAuthError().status_code == _HTTP_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# parse_repo
+# ---------------------------------------------------------------------------
+
+
+class TestParseRepo:
+    def test_valid_repo(self):
+        assert parse_repo("owner/repo") == ("owner", "repo")
+
+    def test_raises_on_missing_slash(self):
+        with pytest.raises(GitHubError, match="Invalid repo format"):
+            parse_repo("noslash")
+
+    def test_raises_on_empty_repo_part(self):
+        with pytest.raises(GitHubError, match="Invalid repo format"):
+            parse_repo("owner/")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_token_sync
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTokenSync:
+    def test_returns_gh_token_env(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "tok_from_env")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert _resolve_token_sync() == "tok_from_env"
+
+    def test_returns_github_token_env(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "tok_github")
+        assert _resolve_token_sync() == "tok_github"
+
+    def test_falls_back_to_gh_auth_token(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ghp_fallback\n"
+        with patch("subprocess.run", return_value=mock_result):
+            assert _resolve_token_sync() == "ghp_fallback"
+
+    def test_returns_none_when_gh_not_found(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert _resolve_token_sync() is None
+
+    def test_returns_none_when_gh_fails(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        with patch("subprocess.run", return_value=mock_result):
+            assert _resolve_token_sync() is None
+
+
+# ---------------------------------------------------------------------------
+# reset_token / get_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetToken:
+    async def test_raises_when_no_token(self, monkeypatch):
+        from codereviewbuddy import github_api
+
+        reset_token()
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run", side_effect=FileNotFoundError), pytest.raises(GitHubAuthError):
+            await github_api.get_token()
+        reset_token()
+
+    async def test_returns_token_from_env(self, monkeypatch):
+        from codereviewbuddy import github_api
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        result = await github_api.get_token()
+        assert result == "tok_test"
+        reset_token()
+
+
+# ---------------------------------------------------------------------------
+# _raise_for_status
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseForStatus:
+    def test_success_does_not_raise(self):
+        _raise_for_status(Response(200))
+
+    def test_401_raises_auth_error(self):
+        with pytest.raises(GitHubAuthError):
+            _raise_for_status(Response(401))
+
+    def test_403_rate_limit_raises_github_error(self):
+        with pytest.raises(GitHubError, match="rate limit"):
+            _raise_for_status(
+                Response(403, json={"message": "API rate limit exceeded for ..."}),
+            )
+
+    def test_403_forbidden_raises_auth_error(self):
+        with pytest.raises(GitHubAuthError, match="forbidden"):
+            _raise_for_status(Response(403, json={"message": "Forbidden"}))
+
+    def test_500_raises_github_error(self):
+        with pytest.raises(GitHubError, match="500"):
+            _raise_for_status(Response(500, json={"message": "Internal Server Error"}))
+
+    def test_non_json_body_uses_text(self):
+        with pytest.raises(GitHubError):
+            _raise_for_status(Response(422, text="Unprocessable"))
+
+    def test_constants_are_correct(self):
+        assert _HTTP_UNAUTHORIZED == 401
+        assert _HTTP_FORBIDDEN == 403
+
+
+# ---------------------------------------------------------------------------
+# _parse_next_link
+# ---------------------------------------------------------------------------
+
+
+class TestParseNextLink:
+    def test_parses_next_link(self):
+        header = '<https://api.github.com/repos?page=2>; rel="next", <https://api.github.com/repos?page=5>; rel="last"'
+        assert _parse_next_link(header) == "https://api.github.com/repos?page=2"
+
+    def test_returns_none_when_no_next(self):
+        assert _parse_next_link('<https://api.github.com/repos?page=1>; rel="prev"') is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _parse_next_link("") is None
+
+
+# ---------------------------------------------------------------------------
+# graphql
+# ---------------------------------------------------------------------------
+
+
+class TestGraphQL:
+    async def test_successful_query(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            respx.post("https://api.github.com/graphql").mock(
+                return_value=Response(200, json={"data": {"viewer": {"login": "user"}}}),
+            )
+            result = await graphql("{ viewer { login } }")
+
+        assert result["data"]["viewer"]["login"] == "user"
+        reset_token()
+        cache.clear()
+
+    async def test_graphql_errors_raise(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            respx.post("https://api.github.com/graphql").mock(
+                return_value=Response(200, json={"errors": [{"message": "Not found"}]}),
+            )
+            with pytest.raises(GitHubError, match="Not found"):
+                await graphql("{ viewer { login } }")
+
+        reset_token()
+        cache.clear()
+
+    async def test_mutation_clears_cache(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            respx.post("https://api.github.com/graphql").mock(
+                return_value=Response(200, json={"data": {"resolveReviewThread": {"thread": {"id": "t1"}}}}),
+            )
+            result = await graphql('mutation { resolveReviewThread(input: {threadId: "t1"}) { thread { id } } }')
+
+        assert "data" in result
+        reset_token()
+        cache.clear()
+
+    async def test_uses_cache_on_second_call(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            route = respx.post("https://api.github.com/graphql").mock(
+                return_value=Response(200, json={"data": {"viewer": {"login": "cached"}}}),
+            )
+            await graphql("{ viewer { login } }")
+            await graphql("{ viewer { login } }")
+            assert route.call_count == 1  # second call served from cache
+
+        reset_token()
+        cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# rest
+# ---------------------------------------------------------------------------
+
+
+class TestRest:
+    async def test_get_request(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            respx.get("https://api.github.com/repos/o/r/pulls").mock(
+                return_value=Response(200, json=[{"number": 1}]),
+            )
+            result = await rest("/repos/o/r/pulls")
+
+        assert result == [{"number": 1}]
+        reset_token()
+        cache.clear()
+
+    async def test_post_request(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            respx.post("https://api.github.com/repos/o/r/issues/1/comments").mock(
+                return_value=Response(201, json={"id": 42}),
+            )
+            result = await rest("/repos/o/r/issues/1/comments", method="POST", body="hello")
+
+        assert result == {"id": 42}
+        reset_token()
+        cache.clear()
+
+    async def test_paginate_follows_link_header(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        page2_url = "https://api.github.com/repos/o/r/pulls?page=2"
+        responses = [
+            Response(200, json=[{"number": 1}], headers={"link": f'<{page2_url}>; rel="next"'}),
+            Response(200, json=[{"number": 2}]),
+        ]
+
+        with respx.mock:
+            respx.get(url__regex=r"https://api\.github\.com/repos/o/r/pulls").mock(
+                side_effect=responses,
+            )
+            result = await rest("/repos/o/r/pulls", paginate=True)
+
+        assert result == [{"number": 1}, {"number": 2}]
+        reset_token()
+        cache.clear()
+
+    async def test_empty_response_returns_none(self, monkeypatch):
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        with respx.mock:
+            respx.delete("https://api.github.com/repos/o/r/issues/1").mock(
+                return_value=Response(204, content=b""),
+            )
+            result = await rest("/repos/o/r/issues/1", method="DELETE")
+
+        assert result is None
+        reset_token()
+        cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# download_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadBytes:
+    async def test_downloads_bytes(self, monkeypatch):
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+
+        with respx.mock:
+            respx.get("https://example.com/archive.zip").mock(
+                return_value=Response(200, content=b"PK\x03\x04"),
+            )
+            result = await download_bytes("https://example.com/archive.zip")
+
+        assert result == b"PK\x03\x04"
+        reset_token()
+
+    async def test_raises_on_http_error(self, monkeypatch):
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+
+        with respx.mock:
+            respx.get("https://example.com/archive.zip").mock(
+                return_value=Response(404),
+            )
+            with pytest.raises(GitHubError):
+                await download_bytes("https://example.com/archive.zip")
+
+        reset_token()

--- a/uv.lock
+++ b/uv.lock
@@ -137,11 +137,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -232,6 +232,7 @@ version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "pydantic-settings" },
 ]
 
@@ -243,6 +244,7 @@ ci = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -271,6 +273,7 @@ maintain = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "pydantic-settings", specifier = ">=2.0" },
 ]
 
@@ -282,6 +285,7 @@ ci = [
     { name = "pytest-cov", specifier = ">=6" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=3.15" },
+    { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.15" },
     { name = "ty", specifier = ">=0.0.14" },
 ]
@@ -1046,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.2"
+version = "9.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1061,9 +1065,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/57/5d3c8c9e2ff9d66dc8f63aa052eb0bac5041fecff7761d8689fe65c39c13/mkdocs_material-9.7.2.tar.gz", hash = "sha256:6776256552290b9b7a7aa002780e25b1e04bc9c3a8516b6b153e82e16b8384bd", size = 4097818, upload-time = "2026-02-18T15:53:07.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b4/f900fcb8e6f510241e334ca401eddcb61ed880fb6572f7f32e4228472ca1/mkdocs_material-9.7.3.tar.gz", hash = "sha256:e5f0a18319699da7e78c35e4a8df7e93537a888660f61a86bd773a7134798f22", size = 4097748, upload-time = "2026-02-24T12:06:22.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/19/d194e75e82282b1d688f0720e21b5ac250ed64ddea333a228aaf83105f2e/mkdocs_material-9.7.2-py3-none-any.whl", hash = "sha256:9bf6f53452d4a4d527eac3cef3f92b7b6fc4931c55d57766a7d87890d47e1b92", size = 9305052, upload-time = "2026-02-18T15:53:05.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1b/16ad0193079bb8a15aa1d2620813a9cd15b18de150a4ea1b2c607fb4c74d/mkdocs_material-9.7.3-py3-none-any.whl", hash = "sha256:37ebf7b4788c992203faf2e71900be3c197c70a4be9b0d72aed537b08a91dd9d", size = 9305078, upload-time = "2026-02-24T12:06:19.155Z" },
 ]
 
 [[package]]
@@ -1237,15 +1241,15 @@ wheels = [
 
 [[package]]
 name = "poethepoet"
-version = "0.42.0"
+version = "0.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pastel" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/9a/4e81fafef2ba94e5c974b4701343d1f053a27575ab5133cbd264348925dd/poethepoet-0.42.0.tar.gz", hash = "sha256:c9a2828259e585e9ed152857602130ff339f7b1638879b80d4a23f25588be4f8", size = 91278, upload-time = "2026-02-22T14:24:50.967Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/9b/e717572686bbf23e17483389c1bf3a381ca2427c84c7e0af0cdc0f23fccc/poethepoet-0.42.1.tar.gz", hash = "sha256:205747e276062c2aaba8afd8a98838f8a3a0237b7ab94715fab8d82718aac14f", size = 93209, upload-time = "2026-02-26T22:57:50.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/3e/58041b7e4d49b69e859dc81c35e221cf02d91ed4dbb5a2f6cc4698a29f44/poethepoet-0.42.0-py3-none-any.whl", hash = "sha256:e43cc20d458ee5bfccaa4572bc5783bcb93991a7d2fcf8dadc9c43f1ebc9b277", size = 118091, upload-time = "2026-02-22T14:24:49.53Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/68/75fa0a5ef39718ea6ba7ab6a3d031fa93640e57585580cec85539540bb65/poethepoet-0.42.1-py3-none-any.whl", hash = "sha256:d8d1345a5ca521be9255e7c13bc2c4c8698ed5e5ac5e9e94890d239fcd423d0a", size = 119967, upload-time = "2026-02-26T22:57:49.467Z" },
 ]
 
 [[package]]
@@ -1677,6 +1681,18 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1741,27 +1757,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.2"
+version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/31/d6e536cdebb6568ae75a7f00e4b4819ae0ad2640c3604c305a0428680b0c/ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1", size = 4569550, upload-time = "2026-02-26T20:04:14.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
-    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
-    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
-    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
-    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/82/c11a03cfec3a4d26a0ea1e571f0f44be5993b923f905eeddfc397c13d360/ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0", size = 10453333, upload-time = "2026-02-26T20:04:20.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/6a1f271f6e31dffb31855996493641edc3eef8077b883eaf007a2f1c2976/ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992", size = 10853356, upload-time = "2026-02-26T20:04:05.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d8/0fab9f8842b83b1a9c2bf81b85063f65e93fb512e60effa95b0be49bfc54/ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba", size = 10187434, upload-time = "2026-02-26T20:03:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cc/cc220fd9394eff5db8d94dec199eec56dd6c9f3651d8869d024867a91030/ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75", size = 10535456, upload-time = "2026-02-26T20:03:52.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0f/bced38fa5cf24373ec767713c8e4cadc90247f3863605fb030e597878661/ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac", size = 10287772, upload-time = "2026-02-26T20:04:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/90/58a1802d84fed15f8f281925b21ab3cecd813bde52a8ca033a4de8ab0e7a/ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a", size = 11049051, upload-time = "2026-02-26T20:04:03.53Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/b7ad36703c35f3866584564dc15f12f91cb1a26a897dc2fd13d7cb3ae1af/ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85", size = 11890494, upload-time = "2026-02-26T20:04:10.497Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/3eb2f47a39a8b0da99faf9c54d3eb24720add1e886a5309d4d1be73a6380/ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db", size = 11326221, upload-time = "2026-02-26T20:04:12.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec", size = 11168459, upload-time = "2026-02-26T20:04:00.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/a64d27688789b06b5d55162aafc32059bb8c989c61a5139a36e1368285eb/ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f", size = 11104366, upload-time = "2026-02-26T20:03:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f6/32d1dcb66a2559763fc3027bdd65836cad9eb09d90f2ed6a63d8e9252b02/ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338", size = 10510887, upload-time = "2026-02-26T20:03:45.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/92/22d1ced50971c5b6433aed166fcef8c9343f567a94cf2b9d9089f6aa80fe/ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc", size = 10285939, upload-time = "2026-02-26T20:04:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f4/7c20aec3143837641a02509a4668fb146a642fd1211846634edc17eb5563/ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68", size = 10765471, upload-time = "2026-02-26T20:03:58.924Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/09/6d2f7586f09a16120aebdff8f64d962d7c4348313c77ebb29c566cefc357/ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3", size = 11263382, upload-time = "2026-02-26T20:04:24.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
 ]
 
 [[package]]
@@ -1849,26 +1865,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.18"
+version = "0.0.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/15/9682700d8d60fdca7afa4febc83a2354b29cdcd56e66e19c92b521db3b39/ty-0.0.18.tar.gz", hash = "sha256:04ab7c3db5dcbcdac6ce62e48940d3a0124f377c05499d3f3e004e264ae94b83", size = 5214774, upload-time = "2026-02-20T21:51:31.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/5e/da108b9eeb392e02ff0478a34e9651490b36af295881cb56575b83f0cc3a/ty-0.0.19.tar.gz", hash = "sha256:ee3d9ed4cb586e77f6efe3d0fe5a855673ca438a3d533a27598e1d3502a2948a", size = 5220026, upload-time = "2026-02-26T12:13:15.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/d8/920460d4c22ea68fcdeb0b2fb53ea2aeb9c6d7875bde9278d84f2ac767b6/ty-0.0.18-py3-none-linux_armv6l.whl", hash = "sha256:4e5e91b0a79857316ef893c5068afc4b9872f9d257627d9bc8ac4d2715750d88", size = 10280825, upload-time = "2026-02-20T21:51:25.03Z" },
-    { url = "https://files.pythonhosted.org/packages/83/56/62587de582d3d20d78fcdddd0594a73822ac5a399a12ef512085eb7a4de6/ty-0.0.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee0e578b3f8416e2d5416da9553b78fd33857868aa1384cb7fefeceee5ff102d", size = 10118324, upload-time = "2026-02-20T21:51:22.27Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2d/dbdace8d432a0755a7417f659bfd5b8a4261938ecbdfd7b42f4c454f5aa9/ty-0.0.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3f7a0487d36b939546a91d141f7fc3dbea32fab4982f618d5b04dc9d5b6da21e", size = 9605861, upload-time = "2026-02-20T21:51:16.066Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d9/de11c0280f778d5fc571393aada7fe9b8bc1dd6a738f2e2c45702b8b3150/ty-0.0.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5e2fa8d45f57ca487a470e4bf66319c09b561150e98ae2a6b1a97ef04c1a4eb", size = 10092701, upload-time = "2026-02-20T21:51:26.862Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/94/068d4d591d791041732171e7b63c37a54494b2e7d28e88d2167eaa9ad875/ty-0.0.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d75652e9e937f7044b1aca16091193e7ef11dac1c7ec952b7fb8292b7ba1f5f2", size = 10109203, upload-time = "2026-02-20T21:51:11.59Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e4/526a4aa56dc0ca2569aaa16880a1ab105c3b416dd70e87e25a05688999f3/ty-0.0.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:563c868edceb8f6ddd5e91113c17d3676b028f0ed380bdb3829b06d9beb90e58", size = 10614200, upload-time = "2026-02-20T21:51:20.298Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/3d/b68ab20a34122a395880922587fbfc3adf090d22e0fb546d4d20fe8c2621/ty-0.0.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:502e2a1f948bec563a0454fc25b074bf5cf041744adba8794d024277e151d3b0", size = 11153232, upload-time = "2026-02-20T21:51:14.121Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ea/678243c042343fcda7e6af36036c18676c355878dcdcd517639586d2cf9e/ty-0.0.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc881dea97021a3aa29134a476937fd8054775c4177d01b94db27fcfb7aab65b", size = 10832934, upload-time = "2026-02-20T21:51:32.92Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/bd/7f8d647cef8b7b346c0163230a37e903c7461c7248574840b977045c77df/ty-0.0.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:421fcc3bc64cab56f48edb863c7c1c43649ec4d78ff71a1acb5366ad723b6021", size = 10700888, upload-time = "2026-02-20T21:51:09.673Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/06/cb3620dc48c5d335ba7876edfef636b2f4498eff4a262ff90033b9e88408/ty-0.0.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0fe5038a7136a0e638a2fb1ad06e3d3c4045314c6ba165c9c303b9aeb4623d6c", size = 10078965, upload-time = "2026-02-20T21:51:07.678Z" },
-    { url = "https://files.pythonhosted.org/packages/60/27/c77a5a84533fa3b685d592de7b4b108eb1f38851c40fac4e79cc56ec7350/ty-0.0.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d123600a52372677613a719bbb780adeb9b68f47fb5f25acb09171de390e0035", size = 10134659, upload-time = "2026-02-20T21:51:18.311Z" },
-    { url = "https://files.pythonhosted.org/packages/43/6e/60af6b88c73469e628ba5253a296da6984e0aa746206f3034c31f1a04ed1/ty-0.0.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bb4bc11d32a1bf96a829bf6b9696545a30a196ac77bbc07cc8d3dfee35e03723", size = 10297494, upload-time = "2026-02-20T21:51:39.631Z" },
-    { url = "https://files.pythonhosted.org/packages/33/90/612dc0b68224c723faed6adac2bd3f930a750685db76dfe17e6b9e534a83/ty-0.0.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dda2efbf374ba4cd704053d04e32f2f784e85c2ddc2400006b0f96f5f7e4b667", size = 10791944, upload-time = "2026-02-20T21:51:37.13Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/da/f4ada0fd08a9e4138fe3fd2bcd3797753593f423f19b1634a814b9b2a401/ty-0.0.18-py3-none-win32.whl", hash = "sha256:c5768607c94977dacddc2f459ace6a11a408a0f57888dd59abb62d28d4fee4f7", size = 9677964, upload-time = "2026-02-20T21:51:42.039Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/fa/090ed9746e5c59fc26d8f5f96dc8441825171f1f47752f1778dad690b08b/ty-0.0.18-py3-none-win_amd64.whl", hash = "sha256:b78d0fa1103d36fc2fce92f2092adace52a74654ab7884d54cdaec8eb5016a4d", size = 10636576, upload-time = "2026-02-20T21:51:29.159Z" },
-    { url = "https://files.pythonhosted.org/packages/92/4f/5dd60904c8105cda4d0be34d3a446c180933c76b84ae0742e58f02133713/ty-0.0.18-py3-none-win_arm64.whl", hash = "sha256:01770c3c82137c6b216aa3251478f0b197e181054ee92243772de553d3586398", size = 10095449, upload-time = "2026-02-20T21:51:34.914Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/31/fd8c6067abb275bea11523d21ecf64e1d870b1ce80cac529cf6636df1471/ty-0.0.19-py3-none-linux_armv6l.whl", hash = "sha256:29bed05d34c8a7597567b8e327c53c1aed4a07dcfbe6c81e6d60c7444936ad77", size = 10268470, upload-time = "2026-02-26T12:13:42.881Z" },
+    { url = "https://files.pythonhosted.org/packages/15/de/16a11bbf7d98c75849fc41f5d008b89bb5d080a4b10dc8ea851ee2bd371b/ty-0.0.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79140870c688c97ec68e723c28935ddef9d91a76d48c68e665fe7c851e628b8a", size = 10098562, upload-time = "2026-02-26T12:13:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4f/086d6ff6686eadf903913c45b53ab96694b62bbfee1d8cf3e55a9b5aa4b2/ty-0.0.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6e9c1f9cfa6a26f7881d14d75cf963af743f6c4189e6aa3e3b4056a65f22e730", size = 9604073, upload-time = "2026-02-26T12:13:24.645Z" },
+    { url = "https://files.pythonhosted.org/packages/95/13/888a6b6c7ed4a880fee91bec997f775153ce86215ee4c56b868516314734/ty-0.0.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbca43b050edf1db2e64ae7b79add233c2aea2855b8a876081bbd032edcd0610", size = 10106295, upload-time = "2026-02-26T12:13:40.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e8/05a372cae8da482de73b8246fb43236bf11e24ac28c879804568108759db/ty-0.0.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8acaa88ab1955ca6b15a0ccc274011c4961377fe65c3948e5d2b212f2517b87c", size = 10098234, upload-time = "2026-02-26T12:13:33.725Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f1/5b0958e9e9576e7662192fe689bbb3dc88e631a4e073db3047793a547d58/ty-0.0.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a901b6a6dd9d17d5b3b2e7bafc3057294e88da3f5de507347316687d7f191a1", size = 10607218, upload-time = "2026-02-26T12:13:17.576Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ab/358c78b77844f58ff5aca368550ab16c719f1ab0ec892ceb1114d7500f4e/ty-0.0.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8deafdaaaee65fd121c66064da74a922d8501be4a2d50049c71eab521a23eff7", size = 11160593, upload-time = "2026-02-26T12:13:36.008Z" },
+    { url = "https://files.pythonhosted.org/packages/95/59/827fc346d66a59fe48e9689a5ceb67dbbd5b4de2e8d4625371af39a2e8b7/ty-0.0.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035e56071af280897441018f74f921b97d53aec0856f8af85f4f949df8eda07d", size = 10822392, upload-time = "2026-02-26T12:13:29.415Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f9/3bbfbbe35478de9bcd63848f4bc9bffda72278dd9732dbad3efc3978432e/ty-0.0.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abdf5885130393ce74501dba792f48ce0a515756ec81c33a4b324bdf3509df6e", size = 10707139, upload-time = "2026-02-26T12:13:20.148Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9e/597023b183ec4ade83a36a0cea5c103f3bffa34f70813d46386c61447fb8/ty-0.0.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:877e89005c8f9d1dbff5ad14cbac9f35c528406fde38926f9b44f24830de8d6a", size = 10096933, upload-time = "2026-02-26T12:13:45.266Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/76/d0d2f6e674db2a17c8efa5e26682b9dfa8d34774705f35902a7b45ebd3bd/ty-0.0.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:39bd1da051c1e4d316efaf79dbed313255633f7c6ad6e24d29f4d9c6ffaf4de6", size = 10109547, upload-time = "2026-02-26T12:13:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b0/76026c06b852a3aa4fdb5bd329fdc2175aaf3c64a3fafece9cc4df167cee/ty-0.0.19-py3-none-musllinux_1_2_i686.whl", hash = "sha256:87df8415a6c9cb27b8f1382fcdc6052e59f5b9f50f78bc14663197eb5c8d3699", size = 10289110, upload-time = "2026-02-26T12:13:38.29Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6c/f3b3a189816b4f079b20fe5d0d7ee38e38a472f53cc6770bb6571147e3de/ty-0.0.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:89b6bb23c332ed5c38dd859eb5793f887abcc936f681a40d4ea68e35eac1af33", size = 10796479, upload-time = "2026-02-26T12:13:10.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/18/caee33d1ce9dd50bd94c26cde7cda4f6971e22e474e7d72a5c86d745ad58/ty-0.0.19-py3-none-win32.whl", hash = "sha256:19b33df3aa7af7b1a9eaa4e1175c3b4dec0f5f2e140243e3492c8355c37418f3", size = 9677215, upload-time = "2026-02-26T12:13:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/18fc0771d0b1da7d7cc2fc9af278d3122b754fe8b521a748734f4e16ecfd/ty-0.0.19-py3-none-win_amd64.whl", hash = "sha256:b9052c61464cdd76bc8e6796f2588c08700f25d0dcbc225bb165e390ea9d96a4", size = 10651252, upload-time = "2026-02-26T12:13:13.035Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/8c/26f7ce8863eb54510082747b3dfb1046ba24f16fc11de18c0e5feb36ff18/ty-0.0.19-py3-none-win_arm64.whl", hash = "sha256:9329804b66dcbae8e7af916ef4963221ed53b8ec7d09b0793591c5ae8a0f3270", size = 10093195, upload-time = "2026-02-26T12:13:26.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Replaces all per-request `gh` CLI subprocess calls with a direct GitHub REST/GraphQL client built on `httpx`. Token is resolved once at startup (env var → `gh auth token` fallback) and reused for every request.

## Why

- **Fixes subprocess hang bug** (#65): `gh` CLI calls block the event loop and were the root cause of the MCP server becoming unresponsive under load.
- **Eliminates `cwd` dependency**: `gh` used the working directory to detect the repo; `httpx` calls use an explicit `repo` parameter or a one-time `gh` fallback, so the server no longer needs a workspace root.
- **Unblocks PAT migration** (#85): The new `github_api.py` layer is the foundation for switching to fine-grained PATs and removing the `gh` CLI runtime dependency entirely.

## Changes

### New: `src/codereviewbuddy/github_api.py`
- `GitHubError` / `GitHubAuthError` exception hierarchy
- `parse_repo()` — splits `owner/repo` strings
- `get_token()` — resolves token once (GH_TOKEN → GITHUB_TOKEN → `gh auth token`), raises `GitHubAuthError` with a magic PAT-creation URL if none found
- `graphql()` — cached GraphQL queries, cache-busting mutations
- `rest()` — cached GET requests, paginated REST with `Link:` header following
- `download_bytes()` — for CI log zip downloads

### Migrated callers
| File | Change |
|---|---|
| `tools/comments.py` | All `gh.graphql`/`gh.rest` → `await github_api.graphql`/`rest`; internal functions made `async` |
| `tools/stack.py` | Same; `_fetch_merged_prs`, `_fetch_pr_summary`, `_fetch_open_prs` now `async` |
| `tools/issues.py` | `create_issue_from_comment` now `async` |
| `tools/descriptions.py` | `_fetch_pr_info` now `async` |
| `server.py` | `await` added to calls that became `async` |

### Tests
- `tests/test_github_api.py` — new; covers token resolution, error types, REST/GraphQL/paginate/download via `respx` mocks
- `tests/test_comments.py`, `test_stack.py`, `test_issues.py` — updated to `AsyncMock`, correct `github_api.*` patch paths, `await` on async calls

## What's not changed yet (follow-up phases)
- `gh.get_repo_info` and `gh.get_current_pr_number` still used as sync fallbacks (wrapped in `asyncio.to_thread`) — Phase 3 will replace these with git + API
- `server.py` workspace detection still present — Phase 4 will simplify
- `ci.py` still uses `gh` for log fetching — Phase 5

Closes #65
Related to #85