### PR TITLE
feat: log httpx call timing to gh_calls.jsonl

### DIFF
--- a/src/codereviewbuddy/github_api.py
+++ b/src/codereviewbuddy/github_api.py
@@ -12,18 +12,22 @@ New users: https://github.com/settings/tokens/new?scopes=repo&description=codere
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
 import subprocess  # noqa: S404
+import time
 from typing import Any
 
 import httpx
 
 from codereviewbuddy import cache
+from codereviewbuddy.gh import _GH_LOG_FILE, _ISSUE_65_TRACKING_TAG
 
 logger = logging.getLogger(__name__)
 
+_GITHUB_API_TIMEOUT_SECS = 30.0
 _GITHUB_API_URL = "https://api.github.com"
 _GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 TOKEN_CREATE_URL = "https://github.com/settings/tokens/new?scopes=repo&description=codereviewbuddy"  # noqa: S105
@@ -135,6 +139,21 @@ def reset_token() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Observability
+# ---------------------------------------------------------------------------
+
+
+def _log_httpx_call(entry: dict[str, Any]) -> None:
+    """Append a JSON log entry to gh_calls.jsonl."""
+    try:
+        _GH_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with _GH_LOG_FILE.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
@@ -221,8 +240,34 @@ async def graphql(query: str, variables: dict[str, Any] | None = None) -> dict[s
         payload["variables"] = variables
 
     logger.debug("GraphQL %s", "mutation" if is_mutation else "query")
-    async with httpx.AsyncClient() as client:
-        response = await client.post(_GITHUB_GRAPHQL_URL, headers=headers, json=payload)
+    start_ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    start = time.perf_counter()
+    status: int | None = None
+    timed_out = False
+    try:
+        async with asyncio.timeout(_GITHUB_API_TIMEOUT_SECS):
+            async with httpx.AsyncClient() as client:
+                response = await client.post(_GITHUB_GRAPHQL_URL, headers=headers, json=payload)
+    except TimeoutError as exc:
+        timed_out = True
+        msg = f"GitHub GraphQL API timed out after {_GITHUB_API_TIMEOUT_SECS:.0f}s"
+        raise GitHubError(msg) from exc
+    else:
+        status = response.status_code
+    finally:
+        log_entry = {
+            "ts": start_ts,
+            "kind": "httpx",
+            "method": "POST",
+            "url": _GITHUB_GRAPHQL_URL,
+            "duration_ms": round((time.perf_counter() - start) * 1000),
+            "tracking_tag": _ISSUE_65_TRACKING_TAG,
+        }
+        if timed_out:
+            log_entry["timed_out"] = True
+        elif status is not None:
+            log_entry["status_code"] = status
+        _log_httpx_call(log_entry)
 
     _raise_for_status(response)
     result: dict[str, Any] = response.json()
@@ -302,8 +347,34 @@ async def _single_rest(url: str, method: str, headers: dict[str, str], **kwargs:
     params = dict(kwargs) if upper == "GET" and kwargs else None
     json_body = dict(kwargs) if upper != "GET" and kwargs else None
 
-    async with httpx.AsyncClient() as client:
-        response = await client.request(method, url, headers=headers, params=params, json=json_body)
+    start_ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    start = time.perf_counter()
+    status: int | None = None
+    timed_out = False
+    try:
+        async with asyncio.timeout(_GITHUB_API_TIMEOUT_SECS):
+            async with httpx.AsyncClient() as client:
+                response = await client.request(method, url, headers=headers, params=params, json=json_body)
+    except TimeoutError as exc:
+        timed_out = True
+        msg = f"GitHub REST API timed out after {_GITHUB_API_TIMEOUT_SECS:.0f}s"
+        raise GitHubError(msg) from exc
+    else:
+        status = response.status_code
+    finally:
+        log_entry = {
+            "ts": start_ts,
+            "kind": "httpx",
+            "method": method,
+            "url": url,
+            "duration_ms": round((time.perf_counter() - start) * 1000),
+            "tracking_tag": _ISSUE_65_TRACKING_TAG,
+        }
+        if timed_out:
+            log_entry["timed_out"] = True
+        elif status is not None:
+            log_entry["status_code"] = status
+        _log_httpx_call(log_entry)
 
     _raise_for_status(response)
     if not response.content:
@@ -317,10 +388,21 @@ async def _paginate_rest(url: str, headers: dict[str, str], **kwargs: Any) -> li
     next_url: str | None = url
     first = True
 
-    async with httpx.AsyncClient() as client:
+    start_ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    start = time.perf_counter()
+    timed_out = False
+    pages = 0
+    client = httpx.AsyncClient()
+    try:
         while next_url:
             params = dict(kwargs) if first and kwargs else None
-            response = await client.get(next_url, headers=headers, params=params)
+            try:
+                async with asyncio.timeout(_GITHUB_API_TIMEOUT_SECS):
+                    response = await client.get(next_url, headers=headers, params=params)
+            except TimeoutError as exc:
+                timed_out = True
+                msg = f"GitHub REST API timed out after {_GITHUB_API_TIMEOUT_SECS:.0f}s"
+                raise GitHubError(msg) from exc
             _raise_for_status(response)
             page = response.json()
             if isinstance(page, list):
@@ -329,6 +411,25 @@ async def _paginate_rest(url: str, headers: dict[str, str], **kwargs: Any) -> li
                 results.append(page)
             next_url = _parse_next_link(response.headers.get("link", ""))
             first = False
+            pages += 1
+    finally:
+        try:
+            async with asyncio.timeout(_GITHUB_API_TIMEOUT_SECS):
+                await client.aclose()
+        except TimeoutError:
+            pass
+        log_entry = {
+            "ts": start_ts,
+            "kind": "httpx",
+            "method": "GET",
+            "url": url,
+            "pages": pages,
+            "duration_ms": round((time.perf_counter() - start) * 1000),
+            "tracking_tag": _ISSUE_65_TRACKING_TAG,
+        }
+        if timed_out:
+            log_entry["timed_out"] = True
+        _log_httpx_call(log_entry)
 
     return results
 
@@ -354,7 +455,33 @@ async def download_bytes(url: str) -> bytes:
         GitHubAuthError: On authentication failure.
     """
     headers = await _get_headers()
-    async with httpx.AsyncClient(follow_redirects=True) as client:
-        response = await client.get(url, headers=headers)
+    start_ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    start = time.perf_counter()
+    status: int | None = None
+    timed_out = False
+    try:
+        async with asyncio.timeout(_GITHUB_API_TIMEOUT_SECS):
+            async with httpx.AsyncClient(follow_redirects=True) as client:
+                response = await client.get(url, headers=headers)
+    except TimeoutError as exc:
+        timed_out = True
+        msg = f"GitHub download timed out after {_GITHUB_API_TIMEOUT_SECS:.0f}s"
+        raise GitHubError(msg) from exc
+    else:
+        status = response.status_code
+    finally:
+        log_entry = {
+            "ts": start_ts,
+            "kind": "httpx",
+            "method": "GET",
+            "url": url,
+            "duration_ms": round((time.perf_counter() - start) * 1000),
+            "tracking_tag": _ISSUE_65_TRACKING_TAG,
+        }
+        if timed_out:
+            log_entry["timed_out"] = True
+        elif status is not None:
+            log_entry["status_code"] = status
+        _log_httpx_call(log_entry)
     _raise_for_status(response)
     return response.content

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -369,3 +369,104 @@ class TestDownloadBytes:
                 await download_bytes("https://example.com/archive.zip")
 
         reset_token()
+
+
+# ---------------------------------------------------------------------------
+# Timeout handling (regression test for issue #65 hang)
+# ---------------------------------------------------------------------------
+
+
+class TestTimeouts:
+    """Verify that a stalled GitHub API never hangs indefinitely.
+
+    These tests patch asyncio.timeout to raise TimeoutError immediately,
+    simulating the TCP-half-open / aclose-hang scenario logged at 00:14:05.
+    """
+
+    async def test_graphql_timeout_raises_github_error(self, monkeypatch):
+        import asyncio
+        from contextlib import asynccontextmanager
+
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        @asynccontextmanager
+        async def _instant_timeout(_seconds):  # noqa: RUF029
+            raise TimeoutError
+            yield
+
+        monkeypatch.setattr(asyncio, "timeout", _instant_timeout)
+
+        with pytest.raises(GitHubError, match="timed out"):
+            await graphql("{ viewer { login } }")
+
+        reset_token()
+        cache.clear()
+
+    async def test_rest_timeout_raises_github_error(self, monkeypatch):
+        import asyncio
+        from contextlib import asynccontextmanager
+
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        @asynccontextmanager
+        async def _instant_timeout(_seconds):  # noqa: RUF029
+            raise TimeoutError
+            yield
+
+        monkeypatch.setattr(asyncio, "timeout", _instant_timeout)
+
+        with pytest.raises(GitHubError, match="timed out"):
+            await rest("/repos/o/r/pulls")
+
+        reset_token()
+        cache.clear()
+
+    async def test_paginated_rest_timeout_raises_github_error(self, monkeypatch):
+        import asyncio
+        from contextlib import asynccontextmanager
+
+        from codereviewbuddy import cache
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+        cache.clear()
+
+        @asynccontextmanager
+        async def _instant_timeout(_seconds):  # noqa: RUF029
+            raise TimeoutError
+            yield
+
+        monkeypatch.setattr(asyncio, "timeout", _instant_timeout)
+
+        with pytest.raises(GitHubError, match="timed out"):
+            await rest("/repos/o/r/pulls", paginate=True)
+
+        reset_token()
+        cache.clear()
+
+    async def test_download_bytes_timeout_raises_github_error(self, monkeypatch):
+        import asyncio
+        from contextlib import asynccontextmanager
+
+        reset_token()
+        monkeypatch.setenv("GH_TOKEN", "tok_test")
+
+        @asynccontextmanager
+        async def _instant_timeout(_seconds):  # noqa: RUF029
+            raise TimeoutError
+            yield
+
+        monkeypatch.setattr(asyncio, "timeout", _instant_timeout)
+
+        with pytest.raises(GitHubError, match="timed out"):
+            await download_bytes("https://example.com/archive.zip")
+
+        reset_token()


### PR DESCRIPTION
## Description

Instruments all four `httpx` call sites in `github_api.py` with per-call timing logged to `~/.codereviewbuddy/gh_calls.jsonl`, completing the observability work started in #134.

Previously, `gh_calls.jsonl` only captured `gh` CLI subprocess timings. When an `httpx` call stalled (e.g. TCP half-open during `aclose()`), there was no record of which call hung or for how long.

### Changes

- **New `_log_httpx_call()` helper** — appends JSON entries to the same `gh_calls.jsonl` file used by the `gh` CLI logger, tagged with `CRB-ISSUE-65-TRACKING`
- **Instrumented call sites** — `graphql()`, `_single_rest()`, `_paginate_rest()`, `download_bytes()` all log `kind`, `method`, `url`, `duration_ms`, `status_code` (on success) or `timed_out: true` (on timeout); paginated calls also log `pages`
- **Uses `try/except/else/finally`** — the `else` clause captures `status_code` only on success; `finally` always fires so partial/failed calls are also logged
- **`asyncio.timeout()` hard deadline** (30 s) already wraps all calls from the previous commit; the logging now makes timeouts visible in the log file

### Log entry examples

Success:
```json
{"ts": "2026-03-02T09:00:00+0100", "kind": "httpx", "method": "POST", "url": "https://api.github.com/graphql", "duration_ms": 312, "status_code": 200, "tracking_tag": "CRB-ISSUE-65-TRACKING"}
```

Timeout:
```json
{"ts": "2026-03-02T09:00:00+0100", "kind": "httpx", "method": "POST", "url": "https://api.github.com/graphql", "duration_ms": 30000, "timed_out": true, "tracking_tag": "CRB-ISSUE-65-TRACKING"}
```

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)

## Related Issues

Related to #65