### PR TITLE
fix: wait for pypi-publish before mcp-registry-publish to avoid race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,6 @@ jobs:
         uv publish
 
   mcp-registry-publish:
-    needs: release
-    if: needs.release.outputs.released == 'true'
+    needs: [release, pypi-publish]
+    if: needs.release.outputs.released == 'true' && (needs.pypi-publish.result == 'success' || needs.pypi-publish.result == 'skipped')
     uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish.yml@main


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
