### PR TITLE
fix: pin copier-update action to SHA (no version tags exist)

### DIFF
--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions-ext/copier-update@v0
+      - uses: actions-ext/copier-update@38801bcaf478d32a26421b470355c490b4c3861e # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The `copier-update.yml` workflow referenced `actions-ext/copier-update@v0`, but the action has never published any version tags — `@v0` does not exist, causing the action resolver to fail.

Pins the action to its latest `main` commit SHA (`38801bc`) following the same pattern used for all other actions in this repo.

## Changes

- `copier-update.yml`: replace `@v0` with `@38801bcaf478d32a26421b470355c490b4c3861e # main`

## Checklist

- [x] Tests added/updated — N/A (workflow-only change)
- [x] Documentation updated (if applicable) — N/A
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)