### PR TITLE
fix: add pid and tool_name fields to io_tap for multi-process detection

### DIFF
--- a/src/codereviewbuddy/io_tap.py
+++ b/src/codereviewbuddy/io_tap.py
@@ -19,6 +19,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+_PID = os.getpid()
+
 logger = logging.getLogger(__name__)
 
 IO_TAP_ENV = "CODEREVIEWBUDDY_IO_TAP"
@@ -82,6 +84,11 @@ def _extract_jsonrpc_info(text: str) -> dict[str, str | int]:
     if isinstance(error_obj, dict) and isinstance(error_obj.get("code"), int):
         info["rpc_error_code"] = error_obj["code"]
 
+    if payload.get("method") == "tools/call":
+        params = payload.get("params")
+        if isinstance(params, dict) and isinstance(params.get("name"), str):
+            info["tool_name"] = params["name"]
+
     return info
 
 
@@ -115,6 +122,7 @@ def _log_entry(
             "direction": direction,
             "bytes": len(data),
             "line": text[:500],
+            "pid": _PID,
             "tracking_tag": ISSUE_65_TRACKING_TAG,
         }
         entry.update(_extract_jsonrpc_info(text))

--- a/tests/test_io_tap.py
+++ b/tests/test_io_tap.py
@@ -68,6 +68,20 @@ class TestExtractJsonrpcInfo:
         info = _extract_jsonrpc_info("not-json")
         assert info["rpc_envelope"] == "parse_error"
 
+    def test_extracts_tool_name_from_tools_call(self):
+        info = _extract_jsonrpc_info(
+            '{"jsonrpc":"2.0","id":41,"method":"tools/call","params":{"name":"summarize_review_status","arguments":{}}}'
+        )
+        assert info["tool_name"] == "summarize_review_status"
+
+    def test_no_tool_name_for_other_methods(self):
+        info = _extract_jsonrpc_info('{"jsonrpc":"2.0","id":1,"method":"roots/list"}')
+        assert "tool_name" not in info
+
+    def test_no_tool_name_when_params_missing(self):
+        info = _extract_jsonrpc_info('{"jsonrpc":"2.0","id":1,"method":"tools/call"}')
+        assert "tool_name" not in info
+
 
 class TestLogEntry:
     def test_writes_jsonl_entry(self, tmp_path: Path):
@@ -84,6 +98,24 @@ class TestLogEntry:
         assert "mono" in entry
         assert entry["phase"] == "data"
         assert entry["tracking_tag"] == ISSUE_65_TRACKING_TAG
+
+    def test_includes_pid(self, tmp_path: Path):
+        import os
+
+        log_file = tmp_path / "tap.jsonl"
+        _log_entry(log_file, "stdin", b'{"jsonrpc":"2.0"}')
+        entry = json.loads(log_file.read_text(encoding="utf-8"))
+        assert entry["pid"] == os.getpid()
+
+    def test_logs_tool_name_for_tools_call(self, tmp_path: Path):
+        log_file = tmp_path / "tap.jsonl"
+        _log_entry(
+            log_file,
+            "stdin",
+            b'{"jsonrpc":"2.0","id":41,"method":"tools/call","params":{"name":"resolve_comment","arguments":{}}}',
+        )
+        entry = json.loads(log_file.read_text(encoding="utf-8"))
+        assert entry["tool_name"] == "resolve_comment"
 
     def test_phase_and_extra(self, tmp_path: Path):
         log_file = tmp_path / "tap.jsonl"


### PR DESCRIPTION
When diagnosing silent response drops (#211), we observed two interleaved ping ID sequences in `io_tap.jsonl` — evidence that two server processes were simultaneously writing to the same stdout pipe. But the log had no `pid` field, so we couldn't confirm which entries came from which process.

This PR adds `"pid": <process_id>` to every `io_tap.jsonl` entry. When the bug reproduces, we'll see two distinct PIDs in the log, proving the two-process stdout corruption hypothesis and pointing directly at the Windsurf/mcp-go restart-with-overlap behaviour as the culprit.

```json
{"ts": "2026-03-03T18:55:31+0100", "dir": "stdout", "phase": "write_start", "pid": 12345, "rpc_id": "41", ...}
```

Also adds `tool_name` extraction for `tools/call` requests (parses `params.name` from the JSON payload), making it possible to correlate a dropped rpc_id directly to the tool that was called without having to decode the raw `line` field.

References #211