### PR TITLE
fix: parenthesize except clause, add encoding to test write_text/read_text calls

### DIFF
--- a/src/codereviewbuddy/_instance.py
+++ b/src/codereviewbuddy/_instance.py
@@ -67,7 +67,7 @@ def _terminate_existing(pid_file: Path) -> None:
         time.sleep(_SIGTERM_WAIT_SECS)
     except ProcessLookupError:
         logger.debug("Previous server process (pid=%d) already exited", old_pid)
-    except PermissionError:
+    except OSError:
         logger.warning(
             "Could not SIGTERM previous server process (pid=%d) — proceeding anyway; stdout corruption may occur",
             old_pid,

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -72,6 +72,12 @@ class TestTerminateExisting:
         with patch("os.kill", side_effect=PermissionError), patch("time.sleep"):
             _terminate_existing(pid_file)
 
+    def test_ignores_oserror_from_kill(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "server.pid"
+        pid_file.write_text("99999999", encoding="utf-8")
+        with patch("os.kill", side_effect=OSError(87, "The parameter is incorrect")), patch("time.sleep"):
+            _terminate_existing(pid_file)
+
     def test_ignores_invalid_pid_content(self, tmp_path: Path) -> None:
         pid_file = tmp_path / "server.pid"
         pid_file.write_text("not-a-pid", encoding="utf-8")


### PR DESCRIPTION
PR #213 merged with two bugs that only surfaced in CI:

1. `except ValueError, OSError:` (PEP 758 syntax) failed on the older Python 3.14 patch the Windows CI runner uses — parenthesized to `except (ValueError, OSError):` for universal compatibility.
2. `os.kill(pid, SIGTERM)` on Windows raises `OSError: [WinError 87] The parameter is incorrect` for invalid PIDs, which wasn't caught by the existing `except ProcessLookupError` handler. Broadened to `except OSError` to cover this case, with a regression test.

Also adds `encoding="utf-8"` to all `write_text`/`read_text` calls in the test file, since Python 3.14 emits `EncodingWarning` when encoding is omitted.