### PR TITLE
fix: fall back to process cwd when MCP roots unavailable

### DIFF
--- a/src/codereviewbuddy/gh.py
+++ b/src/codereviewbuddy/gh.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 import subprocess  # noqa: S404
 import time
 from pathlib import Path
@@ -24,6 +25,26 @@ _GH_ROTATE_EVERY_WRITES = 100
 _gh_log_state: dict[str, int] = {"write_count": 0}
 # Unique sentinel to grep/remove all temporary diagnostics once issue #65 is resolved.
 _ISSUE_65_TRACKING_TAG = "CRB-ISSUE-65-TRACKING"
+
+
+def _git_root_for_cwd(cwd: str) -> str | None:
+    """Return the git repository root for ``cwd``, or ``None`` if not inside a repo."""
+    git = shutil.which("git")
+    if not git:
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603
+            [git, "rev-parse", "--show-toplevel"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception as exc:
+        logger.debug("git rev-parse failed in %s: %s", cwd, exc)
+    return None
 
 
 def _truncate_gh_log_if_needed() -> None:

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -11,6 +11,7 @@ import importlib
 import importlib.util
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
 from fastmcp import FastMCP
@@ -63,7 +64,7 @@ async def _get_workspace_cwd(ctx: Context | None = None) -> str | None:
     Priority:
     1. MCP roots — per-window, protocol-correct (works with multi-window setups).
     2. ``CRB_WORKSPACE`` env var — fallback for clients that don't send roots.
-    3. ``None`` — falls back to the server's process cwd.
+    3. Process cwd — only if it resolves to a git repository root.
 
     See #142, #174.
     """
@@ -98,13 +99,17 @@ async def _get_workspace_cwd(ctx: Context | None = None) -> str | None:
         logger.debug("Workspace from CRB_WORKSPACE: %s", env_ws)
         return env_ws
 
-    # 3. Process cwd (weakest — almost certainly wrong in MCP context)
-    if ctx is not None:
+    # 3. Process cwd — only if it is inside a git repository.
+    #    Windsurf sets process cwd to "/" for MCP servers, so we guard against
+    #    non-repo directories to avoid confusing gh errors downstream.
+    git_root = await asyncio.to_thread(gh._git_root_for_cwd, str(Path.cwd()))
+    if git_root:
         logger.warning(
-            "Workspace not detected (MCP roots unavailable, CRB_WORKSPACE not set). "
-            "Auto-detection of repo/branch will use the server's process directory "
-            "and may produce wrong results.",
+            "Workspace not detected (MCP roots unavailable, CRB_WORKSPACE not set). Using git root from process cwd: %s",
+            git_root,
         )
+        return git_root
+
     return None
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,7 +88,7 @@ class TestMain:
 
 
 class TestGetWorkspaceCwd:
-    """Tests for _get_workspace_cwd — MCP roots → CRB_WORKSPACE → None cascade (#142)."""
+    """Tests for _get_workspace_cwd — MCP roots → CRB_WORKSPACE → process cwd cascade (#142, #174)."""
 
     async def test_roots_take_priority_over_env_var(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
@@ -131,18 +131,20 @@ class TestGetWorkspaceCwd:
 
         assert await _get_workspace_cwd(ctx) == "/from/env"
 
-    async def test_returns_none_without_context_or_env(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_falls_back_to_git_root_without_context_or_env(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         monkeypatch.delenv("CRB_WORKSPACE", raising=False)
-        assert await _get_workspace_cwd(None) is None
+        mocker.patch("codereviewbuddy.server.gh._git_root_for_cwd", return_value="/git/root")
+        assert await _get_workspace_cwd(None) == "/git/root"
 
-    async def test_returns_none_when_roots_empty_no_env(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+    async def test_falls_back_to_git_root_when_roots_empty_no_env(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
 
         monkeypatch.delenv("CRB_WORKSPACE", raising=False)
+        mocker.patch("codereviewbuddy.server.gh._git_root_for_cwd", return_value="/git/root")
         ctx = mocker.MagicMock()
         ctx.list_roots = AsyncMock(return_value=[])
 
-        assert await _get_workspace_cwd(ctx) is None
+        assert await _get_workspace_cwd(ctx) == "/git/root"
 
     async def test_env_var_fallback_on_roots_exception(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
@@ -153,25 +155,32 @@ class TestGetWorkspaceCwd:
 
         assert await _get_workspace_cwd(ctx) == "/from/env"
 
-    async def test_returns_none_on_roots_exception_no_env(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+    async def test_falls_back_to_git_root_on_roots_exception_no_env(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
 
         monkeypatch.delenv("CRB_WORKSPACE", raising=False)
+        mocker.patch("codereviewbuddy.server.gh._git_root_for_cwd", return_value="/git/root")
         ctx = mocker.MagicMock()
         ctx.list_roots = AsyncMock(side_effect=Exception("roots not supported"))
 
-        assert await _get_workspace_cwd(ctx) is None
+        assert await _get_workspace_cwd(ctx) == "/git/root"
 
-    async def test_unsupported_scheme_falls_through(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+    async def test_unsupported_scheme_falls_through_to_git_root(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
         from unittest.mock import AsyncMock
 
         monkeypatch.delenv("CRB_WORKSPACE", raising=False)
+        mocker.patch("codereviewbuddy.server.gh._git_root_for_cwd", return_value="/git/root")
         root = mocker.MagicMock()
         root.uri = "https://example.com/repo"
         ctx = mocker.MagicMock()
         ctx.list_roots = AsyncMock(return_value=[root])
 
-        assert await _get_workspace_cwd(ctx) is None
+        assert await _get_workspace_cwd(ctx) == "/git/root"
+
+    async def test_returns_none_when_not_in_git_repo(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+        monkeypatch.delenv("CRB_WORKSPACE", raising=False)
+        mocker.patch("codereviewbuddy.server.gh._git_root_for_cwd", return_value=None)
+        assert await _get_workspace_cwd(None) is None
 
 
 class TestCheckAutoDetectPrerequisites:


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
