### PR TITLE
chore: slim down PR template, gitignore .brv/, fix stale docstring

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,4 @@
-## Description
+Closes ISM-XXX
 
-<!-- Brief description of what this PR does -->
-
-## Checklist
-
-- [ ] Tests added/updated
-- [ ] Documentation updated (if applicable)
-- [ ] `poe check` passes
-- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)
-
-## Related Issues
-
-<!-- Link related issues: Fixes #123, Related to #456 -->
+<!-- Replace ISM-XXX with the Linear issue this PR closes (auto-transitions to Done on merge).
+     Use "Ref ISM-XXX" to link without closing. Delete the line for chore PRs with no issue. -->

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 /htmlcov/
 /site/
 
+# byterover (cloud sync via brv push/pull — no need to track in git)
+.brv/
+
 # cache
 .cache/
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An MCP server that helps your AI coding agent manage PR review comments from any
 
 ### Review comment management
 
-- **List review comments** — inline threads, PR-level reviews, and bot comments (codecov, netlify, vercel, etc.) with reviewer identification and staleness detection
+- **List review comments** — inline threads, PR-level reviews, and bot comments (codecov, netlify, vercel, etc.) with reviewer identification
 - **Stacked PR support** — `list_stack_review_comments` fetches comments across an entire PR stack in one call
 - **Reply to anything** — inline review threads (`PRRT_`), PR-level reviews (`PRR_`), and bot issue comments (`IC_`) all routed to the correct GitHub API
 
@@ -181,7 +181,7 @@ If your MCP client reports `No module named 'fastmcp.server.tasks.routing'`, the
 | ---- | ---- | ----------- |
 | `summarize_review_status` | query, discovery | Lightweight stack-wide overview with severity counts — start here |
 | `triage_review_comments` | query | Only actionable threads, pre-classified with severity and suggested actions |
-| `list_review_comments` | query | All review threads with reviewer ID, status, staleness, and auto-discovered stack |
+| `list_review_comments` | query | All review threads with reviewer ID, status, and auto-discovered stack |
 | `list_stack_review_comments` | query | Comments for multiple PRs in one call, grouped by PR number |
 | `reply_to_comment` | command | Reply to inline threads (`PRRT_`), PR-level reviews (`PRR_`), or bot comments (`IC_`) |
 | `create_issue_from_comment` | command | Create a GitHub issue from a review comment with labels and PR backlink |

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -329,7 +329,7 @@ async def list_review_comments(
     repo: str | None = None,
     status: Literal["resolved", "unresolved"] | None = None,
 ) -> ReviewSummary:
-    """List all review threads for a PR with reviewer identification and staleness.
+    """List all review threads for a PR with reviewer identification.
 
     After fetching, always present a summary to the user:
     1. Group comments by file for readability.


### PR DESCRIPTION
Housekeeping PR with three small changes:

- **Slim PR template** — replaced the unused Description/Checklist/Related Issues boilerplate with just `Closes ISM-XXX` at the top so Linear issues auto-close on merge
- **Gitignore all of `.brv/`** — now that ByteRover cloud sync is active (`brv push/pull`), the local context-tree markdown files no longer need to be tracked in git
- **Fix stale docstring** — removed mention of "staleness" from `list_review_comments` docstring (feature was removed in a previous PR)