### PR TITLE
feat: add CRB_OWNER_LOGINS env var for triage owner detection

### DIFF
--- a/src/codereviewbuddy/cli.py
+++ b/src/codereviewbuddy/cli.py
@@ -100,6 +100,7 @@ _KNOWN_ENV_PREFIXES = frozenset({
     "CRB_PR_DESCRIPTIONS",
     "CRB_SELF_IMPROVEMENT",
     "CRB_DIAGNOSTICS",
+    "CRB_OWNER_LOGINS",
     "CRB_WORKSPACE",
 })
 
@@ -151,4 +152,9 @@ def _print_config_summary(config: object) -> None:
     if diag.include_args_fingerprint:
         diag_flags.append("args_fingerprint")
     print(f"  Diagnostics: {', '.join(diag_flags) if diag_flags else 'all off'}")
+
+    if config.owner_logins:
+        print(f"  Owner logins: {', '.join(config.owner_logins)}")
+    else:
+        print("  Owner logins: not set (owner-reply filtering disabled)")
     print()

--- a/src/codereviewbuddy/config.py
+++ b/src/codereviewbuddy/config.py
@@ -89,6 +89,10 @@ class Config(BaseModel):
         default_factory=DiagnosticsConfig,
         description="Diagnostic and debugging settings",
     )
+    owner_logins: list[str] = Field(
+        default_factory=list,
+        description="GitHub usernames considered 'ours' for triage filtering (JSON list in env, e.g. '[\"alice\",\"bob\"]')",
+    )
 
 
 def load_config() -> Config:
@@ -116,12 +120,14 @@ def load_config() -> Config:
         pr_descriptions: PRDescriptionsConfig = Field(default_factory=PRDescriptionsConfig)
         self_improvement: SelfImprovementConfig = Field(default_factory=SelfImprovementConfig)
         diagnostics: DiagnosticsConfig = Field(default_factory=DiagnosticsConfig)
+        owner_logins: list[str] = Field(default_factory=list)
 
     env = _EnvConfig()
     config = Config(
         pr_descriptions=env.pr_descriptions,
         self_improvement=env.self_improvement,
         diagnostics=env.diagnostics,
+        owner_logins=env.owner_logins,
     )
     logger.info("Config loaded from CRB_* env vars")
     return config

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -626,7 +626,7 @@ async def triage_review_comments(
         pr_numbers: PR numbers to triage (use stack from ``summarize_review_status``).
         repo: Repository in "owner/repo" format. Auto-detected if not provided.
         owner_logins: GitHub usernames considered "ours" (agent + human).
-            Defaults to ["ichoosetoaccept"]. Add your own username if needed.
+            Defaults to CRB_OWNER_LOGINS env var. Pass explicitly to override.
 
     Returns:
         TriageResult with actionable items sorted by severity (bugs first),

--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Literal
 from fastmcp.utilities.async_utils import call_sync_fn_in_threadpool
 
 from codereviewbuddy import gh, github_api
+from codereviewbuddy.config import get_config
 from codereviewbuddy.models import (
     CommentStatus,
     ReviewComment,
@@ -621,14 +622,18 @@ async def triage_review_comments(
         pr_numbers: PR numbers to triage.
         repo: Repository in "owner/repo" format. Auto-detected if not provided.
         owner_logins: GitHub usernames considered "ours" (agent + human).
-            Defaults to ``["ichoosetoaccept"]`` if not provided.
+            Defaults to ``CRB_OWNER_LOGINS`` config value if not provided.
         cwd: Working directory for git operations.
         ctx: FastMCP context for progress reporting.
 
     Returns:
         TriageResult with only actionable items, sorted by severity.
     """
-    owners = frozenset(owner_logins or ["ichoosetoaccept"])
+    configured_owners = get_config().owner_logins
+    resolved = owner_logins if owner_logins is not None else configured_owners
+    if not resolved:
+        logger.warning("No owner_logins configured — owner-reply filtering is disabled. Set CRB_OWNER_LOGINS to enable.")
+    owners = frozenset(resolved)
     items: list[TriageItem] = []
     issue_items: list[TriageItem] = []
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,14 @@ class TestConfig:
         config = SelfImprovementConfig(enabled=False)
         assert not config.repo
 
+    def test_owner_logins_defaults_empty(self):
+        config = Config()
+        assert config.owner_logins == []
+
+    def test_owner_logins_explicit(self):
+        config = Config(owner_logins=["alice", "bob"])
+        assert config.owner_logins == ["alice", "bob"]
+
     def test_diagnostics_defaults(self):
         from codereviewbuddy.config import DiagnosticsConfig
 
@@ -98,6 +106,15 @@ class TestLoadConfigFromEnv:
         monkeypatch.setenv("CRB_PR_DESCRIPTIONS__ENABLED", "false")
         config = load_config()
         assert config.pr_descriptions.enabled is False
+
+    def test_owner_logins_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CRB_OWNER_LOGINS", '["alice","bob"]')
+        config = load_config()
+        assert config.owner_logins == ["alice", "bob"]
+
+    def test_owner_logins_empty_by_default(self):
+        config = load_config()
+        assert config.owner_logins == []
 
     def test_unknown_env_vars_ignored(self, monkeypatch: pytest.MonkeyPatch):
         """CRB_ env vars for unknown fields should be silently ignored."""

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -209,7 +209,7 @@ class TestTriageReviewComments:
         )
         self._mock_list(mocker, [replied])
 
-        result = await triage_review_comments([42], repo="o/r")
+        result = await triage_review_comments([42], repo="o/r", owner_logins=["ichoosetoaccept"])
         assert result.total == 0
 
     async def test_pr_review_excluded(self, mocker: MockerFixture):
@@ -229,7 +229,7 @@ class TestTriageReviewComments:
         )
         self._mock_list(mocker, [thread])
 
-        result = await triage_review_comments([42], repo="o/r")
+        result = await triage_review_comments([42], repo="o/r", owner_logins=["ichoosetoaccept"])
         assert result.total == 1
         assert result.needs_issue == 1
         assert result.items[0].action == "create_issue"
@@ -243,7 +243,7 @@ class TestTriageReviewComments:
         )
         self._mock_list(mocker, [thread])
 
-        result = await triage_review_comments([42], repo="o/r")
+        result = await triage_review_comments([42], repo="o/r", owner_logins=["ichoosetoaccept"])
         assert result.total == 0
 
     async def test_sorted_by_severity(self, mocker: MockerFixture):
@@ -293,13 +293,40 @@ class TestTriageReviewComments:
         )
         self._mock_list(mocker, [thread])
 
-        # With default owner — thread should appear (mybot isn't ichoosetoaccept)
+        # With no config and no param — no owner filtering, thread appears
         result = await triage_review_comments([42], repo="o/r")
         assert result.total == 1
 
         # With custom owner — thread should be excluded
         result = await triage_review_comments([42], repo="o/r", owner_logins=["mybot"])
         assert result.total == 0
+
+    async def test_owner_logins_from_config(self, mocker: MockerFixture):
+        """CRB_OWNER_LOGINS config should be used when owner_logins param is omitted."""
+        from codereviewbuddy.config import Config, set_config
+
+        thread = _thread(
+            extra_comments=[
+                ReviewComment(author="myagent", body="Fixed"),
+            ]
+        )
+        self._mock_list(mocker, [thread])
+
+        # Set config with owner_logins
+        set_config(Config(owner_logins=["myagent"]))
+        try:
+            result = await triage_review_comments([42], repo="o/r")
+            assert result.total == 0  # myagent reply detected as owner
+
+            # Explicit param overrides config
+            result = await triage_review_comments([42], repo="o/r", owner_logins=["someone_else"])
+            assert result.total == 1  # myagent isn't "someone_else"
+
+            # Explicit empty list disables filtering even when config has owners
+            result = await triage_review_comments([42], repo="o/r", owner_logins=[])
+            assert result.total == 1  # empty owners = no filtering
+        finally:
+            set_config(Config())  # Reset to defaults
 
     async def test_snippet_truncated(self, mocker: MockerFixture):
         """Snippet should be truncated to 200 chars."""


### PR DESCRIPTION
Closes ISM-326

Replaces the hardcoded `["ichoosetoaccept"]` fallback in `triage_review_comments` with a configurable `CRB_OWNER_LOGINS` env var.

**Changes:**
- Add `owner_logins: list[str]` to `Config` / `_EnvConfig` (defaults to empty list)
- `triage_review_comments` reads `get_config().owner_logins` when no explicit param passed
- Add `CRB_OWNER_LOGINS` to `_KNOWN_ENV_PREFIXES` in cli.py
- Tests for config loading, env var parsing, and config-based triage filtering

**Usage in MCP client config:**
```json
{"CRB_OWNER_LOGINS": "[\"ichoosetoaccept\", \"mybot\"]"}
```