### PR TITLE
feat: size-based log rotation for diagnostic JSONL files

### DIFF
--- a/src/codereviewbuddy/_instance.py
+++ b/src/codereviewbuddy/_instance.py
@@ -39,6 +39,13 @@ def enforce_single_instance(pid_file: Path | None = None) -> Path:
         pid_file = _PID_DIR / f"server.{os.getppid()}.pid"
     pid_file.parent.mkdir(parents=True, exist_ok=True)
 
+    # Clean up stale PID files from dead processes (e.g. crashed servers)
+    from codereviewbuddy.log_rotation import cleanup_stale_pid_files  # noqa: PLC0415
+
+    removed = cleanup_stale_pid_files(pid_file.parent)
+    if removed:
+        logger.info("Cleaned up %d stale PID file(s)", removed)
+
     if pid_file.exists():
         _terminate_existing(pid_file)
 

--- a/src/codereviewbuddy/gh.py
+++ b/src/codereviewbuddy/gh.py
@@ -15,14 +15,13 @@ from pathlib import Path
 from typing import Any
 
 from codereviewbuddy import cache
+from codereviewbuddy.log_rotation import _CHECK_EVERY_WRITES, rotate_if_needed
 
 logger = logging.getLogger(__name__)
 
 _GH_LOG_DIR = Path.home() / ".codereviewbuddy"
 _GH_LOG_FILE = _GH_LOG_DIR / "gh_calls.jsonl"
-_MAX_GH_LOG_LINES = 10_000
-_GH_ROTATE_EVERY_WRITES = 100
-_gh_log_state: dict[str, int] = {"write_count": 0}
+_gh_log_write_count: int = 0
 # Unique sentinel to grep/remove all temporary diagnostics once issue #65 is resolved.
 _ISSUE_65_TRACKING_TAG = "CRB-ISSUE-65-TRACKING"
 
@@ -47,28 +46,16 @@ def _git_root_for_cwd(cwd: str) -> str | None:
     return None
 
 
-def _truncate_gh_log_if_needed() -> None:
-    """Keep only the last N gh call log entries."""
-    try:
-        if not _GH_LOG_FILE.exists():
-            return
-        lines = _GH_LOG_FILE.read_text(encoding="utf-8").splitlines()
-        if len(lines) <= _MAX_GH_LOG_LINES:
-            return
-        _GH_LOG_FILE.write_text("\n".join(lines[-_MAX_GH_LOG_LINES:]) + "\n", encoding="utf-8")
-    except OSError:
-        pass
-
-
 def _log_gh_call(entry: dict[str, Any]) -> None:
     """Append a JSON log entry to gh_calls.jsonl."""
+    global _gh_log_write_count  # noqa: PLW0603
     try:
         _GH_LOG_DIR.mkdir(parents=True, exist_ok=True)
         with _GH_LOG_FILE.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry, default=str) + "\n")
-        _gh_log_state["write_count"] += 1
-        if _gh_log_state["write_count"] % _GH_ROTATE_EVERY_WRITES == 0:
-            _truncate_gh_log_if_needed()
+        _gh_log_write_count += 1
+        if _gh_log_write_count % _CHECK_EVERY_WRITES == 0:
+            rotate_if_needed(_GH_LOG_FILE)
     except OSError:
         pass
 

--- a/src/codereviewbuddy/github_api.py
+++ b/src/codereviewbuddy/github_api.py
@@ -27,6 +27,9 @@ import httpx
 
 from codereviewbuddy import cache
 from codereviewbuddy.gh import _GH_LOG_FILE, _ISSUE_65_TRACKING_TAG
+from codereviewbuddy.log_rotation import _CHECK_EVERY_WRITES, rotate_if_needed
+
+_httpx_log_write_count: int = 0
 
 logger = logging.getLogger(__name__)
 
@@ -148,10 +151,14 @@ def reset_token() -> None:
 
 def _log_httpx_call(entry: dict[str, Any]) -> None:
     """Append a JSON log entry to gh_calls.jsonl."""
+    global _httpx_log_write_count  # noqa: PLW0603
     try:
         _GH_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         with _GH_LOG_FILE.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry, default=str) + "\n")
+        _httpx_log_write_count += 1
+        if _httpx_log_write_count % _CHECK_EVERY_WRITES == 0:
+            rotate_if_needed(_GH_LOG_FILE)
     except OSError:
         pass
 

--- a/src/codereviewbuddy/io_tap.py
+++ b/src/codereviewbuddy/io_tap.py
@@ -19,6 +19,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from codereviewbuddy.log_rotation import _CHECK_EVERY_WRITES, rotate_if_needed
+
 _PID = os.getpid()
 
 logger = logging.getLogger(__name__)
@@ -26,28 +28,13 @@ logger = logging.getLogger(__name__)
 IO_TAP_ENV = "CODEREVIEWBUDDY_IO_TAP"
 LOG_DIR = Path.home() / ".codereviewbuddy"
 LOG_FILE = LOG_DIR / "io_tap.jsonl"
-MAX_IO_TAP_LOG_LINES = 10_000
-_ROTATE_EVERY_WRITES = 100
-_io_tap_log_state: dict[str, int] = {"write_count": 0}
+_io_tap_write_count: int = 0
 # Unique sentinel to grep/remove temporary diagnostics once issue #65 is resolved.
 ISSUE_65_TRACKING_TAG = "CRB-ISSUE-65-TRACKING"
 
 
 _JSONRPC_ID_RE = re.compile(r'"id"\s*:\s*(\d+|"[^"]*")')
 _JSONRPC_METHOD_RE = re.compile(r'"method"\s*:\s*"([^"]+)"')
-
-
-def _truncate_io_tap_log_if_needed(log_path: Path) -> None:
-    """Keep only the last N io_tap log entries."""
-    try:
-        if not log_path.exists():
-            return
-        lines = log_path.read_text(encoding="utf-8").splitlines()
-        if len(lines) <= MAX_IO_TAP_LOG_LINES:
-            return
-        log_path.write_text("\n".join(lines[-MAX_IO_TAP_LOG_LINES:]) + "\n", encoding="utf-8")
-    except OSError:
-        pass
 
 
 def _extract_jsonrpc_info(text: str) -> dict[str, str | int]:
@@ -130,9 +117,10 @@ def _log_entry(
             entry.update(extra)
         with log_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
-        _io_tap_log_state["write_count"] += 1
-        if _io_tap_log_state["write_count"] % _ROTATE_EVERY_WRITES == 0:
-            _truncate_io_tap_log_if_needed(log_path)
+        global _io_tap_write_count  # noqa: PLW0603
+        _io_tap_write_count += 1
+        if _io_tap_write_count % _CHECK_EVERY_WRITES == 0:
+            rotate_if_needed(log_path)
     except Exception:
         logger.debug("Failed to write I/O tap entry", exc_info=True)
 
@@ -286,7 +274,7 @@ def install_io_tap() -> bool:
 
     try:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
-        _truncate_io_tap_log_if_needed(LOG_FILE)
+        rotate_if_needed(LOG_FILE)
     except OSError:
         logger.warning("Failed to create I/O tap log directory: %s", LOG_DIR)
         return False

--- a/src/codereviewbuddy/log_rotation.py
+++ b/src/codereviewbuddy/log_rotation.py
@@ -1,0 +1,85 @@
+"""Size-based log rotation for diagnostic JSONL files.
+
+Rotates ``foo.jsonl`` → ``foo.jsonl.1`` → … → ``foo.jsonl.N`` when the
+active file exceeds *max_bytes*.  Oldest backup beyond *backup_count* is
+deleted.  Safe to call from multiple concurrent processes — worst case a
+few extra lines land before one process triggers the rename cascade.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_BYTES: int = 2 * 1024 * 1024  # 2 MB
+DEFAULT_BACKUP_COUNT: int = 7
+_CHECK_EVERY_WRITES: int = 50
+
+
+def rotate_if_needed(
+    log_path: Path,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    backup_count: int = DEFAULT_BACKUP_COUNT,
+) -> bool:
+    """Rotate *log_path* if it exceeds *max_bytes*.
+
+    Returns ``True`` if a rotation was performed.
+    """
+    try:
+        if not log_path.exists():
+            return False
+        if log_path.stat().st_size <= max_bytes:
+            return False
+        _do_rotate(log_path, backup_count)
+    except OSError:
+        logger.debug("Log rotation failed for %s", log_path, exc_info=True)
+        return False
+    else:
+        return True
+
+
+def _do_rotate(log_path: Path, backup_count: int) -> None:
+    """Perform the actual file rename cascade."""
+    # Delete the oldest backup if it exists
+    oldest = Path(f"{log_path}.{backup_count}")
+    if oldest.exists():
+        oldest.unlink()
+
+    # Shift backups: .6 → .7, .5 → .6, …, .1 → .2
+    for i in range(backup_count - 1, 0, -1):
+        src = Path(f"{log_path}.{i}")
+        dst = Path(f"{log_path}.{i + 1}")
+        if src.exists():
+            src.rename(dst)
+
+    # Rotate current file → .1
+    log_path.rename(Path(f"{log_path}.1"))
+
+
+def cleanup_stale_pid_files(log_dir: Path) -> int:
+    """Remove ``server.*.pid`` files whose processes are no longer running.
+
+    Returns the number of stale PID files removed.
+    """
+    removed = 0
+    try:
+        for pid_file in log_dir.glob("server.*.pid"):
+            try:
+                pid = int(pid_file.read_text(encoding="utf-8").strip())
+                # os.kill(pid, 0) raises OSError if process doesn't exist
+                os.kill(pid, 0)
+            except ValueError, ProcessLookupError:
+                pid_file.unlink(missing_ok=True)
+                removed += 1
+            except PermissionError:
+                pass  # Process exists but we can't signal it
+            except OSError:
+                pid_file.unlink(missing_ok=True)
+                removed += 1
+    except OSError:
+        logger.debug("Failed to clean up PID files in %s", log_dir, exc_info=True)
+    return removed

--- a/src/codereviewbuddy/middleware.py
+++ b/src/codereviewbuddy/middleware.py
@@ -20,6 +20,8 @@ from typing import Any
 
 from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
 
+from codereviewbuddy.log_rotation import _CHECK_EVERY_WRITES, rotate_if_needed
+
 logger = logging.getLogger(__name__)
 
 WRITE_TOOLS = frozenset({
@@ -32,7 +34,6 @@ RAPID_WRITE_WINDOW_SECONDS = 2.0
 
 LOG_DIR = Path.home() / ".codereviewbuddy"
 LOG_FILE = LOG_DIR / "tool_calls.jsonl"
-MAX_LOG_LINES = 1000
 # Unique sentinel to grep/remove all temporary diagnostics once issue #65 is resolved.
 ISSUE_65_TRACKING_TAG = "CRB-ISSUE-65-TRACKING"
 
@@ -95,17 +96,6 @@ class WriteOperationMiddleware(Middleware):
                 f.write(json.dumps(entry, default=str) + "\n")
         except OSError:
             logger.warning("Could not write to log file: %s", self._log_file)
-
-    def _truncate_log_if_needed(self) -> None:
-        """Keep only the last MAX_LOG_LINES entries."""
-        try:
-            if not self._log_file.exists():
-                return
-            lines = self._log_file.read_text(encoding="utf-8").splitlines()
-            if len(lines) > MAX_LOG_LINES:
-                self._log_file.write_text("\n".join(lines[-MAX_LOG_LINES:]) + "\n", encoding="utf-8")
-        except OSError:
-            pass
 
     def _check_rapid_writes(self, now: float) -> str | None:
         """Check if we're in a rapid write sequence. Returns warning message or None."""
@@ -275,5 +265,5 @@ class WriteOperationMiddleware(Middleware):
                 entry["cancelled"] = True
             self._append_log(entry)
             self._log_count += 1
-            if self._log_count % 100 == 0:
-                self._truncate_log_if_needed()
+            if self._log_count % _CHECK_EVERY_WRITES == 0:
+                rotate_if_needed(self._log_file)

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
 
 from codereviewbuddy import cache
@@ -247,22 +249,24 @@ class TestRunGhLogging:
         assert entry["error"] == "FileNotFoundError"
         assert entry["cmd"] == "auth status"
 
-    def test_log_rotation_keeps_last_entries(self, mocker: MockerFixture, tmp_path):
+    def test_log_rotation_triggers(self, mocker: MockerFixture, tmp_path: Path):
         from codereviewbuddy import gh as gh_module
 
         log_file = tmp_path / "gh_calls.jsonl"
         mocker.patch("codereviewbuddy.gh._GH_LOG_DIR", tmp_path)
         mocker.patch("codereviewbuddy.gh._GH_LOG_FILE", log_file)
-        mocker.patch("codereviewbuddy.gh._MAX_GH_LOG_LINES", 3)
-        mocker.patch("codereviewbuddy.gh._GH_ROTATE_EVERY_WRITES", 1)
-        mocker.patch("codereviewbuddy.gh._gh_log_state", {"write_count": 0})
 
-        for i in range(5):
+        rotate_mock = mocker.patch("codereviewbuddy.gh.rotate_if_needed")
+        # Reset write count so we can control the trigger
+        mocker.patch("codereviewbuddy.gh._gh_log_write_count", 0)
+
+        from codereviewbuddy.log_rotation import _CHECK_EVERY_WRITES
+
+        # Write exactly _CHECK_EVERY_WRITES entries
+        for i in range(_CHECK_EVERY_WRITES):
             gh_module._log_gh_call({"i": i})
 
-        lines = log_file.read_text(encoding="utf-8").splitlines()
-        assert len(lines) == 3
-        assert [json.loads(line)["i"] for line in lines] == [2, 3, 4]
+        rotate_mock.assert_called_once_with(log_file)
 
 
 class TestCheckAuth:

--- a/tests/test_io_tap.py
+++ b/tests/test_io_tap.py
@@ -175,18 +175,20 @@ class TestLogEntry:
         assert entry["dir"] == "stdin"
         assert entry["direction"] == "stdin"
 
-    def test_rotation_keeps_last_entries(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_rotation_triggers_on_write_count(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """rotate_if_needed should be called every _CHECK_EVERY_WRITES writes."""
         log_file = tmp_path / "tap.jsonl"
-        monkeypatch.setattr("codereviewbuddy.io_tap.MAX_IO_TAP_LOG_LINES", 3)
-        monkeypatch.setattr("codereviewbuddy.io_tap._ROTATE_EVERY_WRITES", 1)
-        monkeypatch.setattr("codereviewbuddy.io_tap._io_tap_log_state", {"write_count": 0})
+        monkeypatch.setattr("codereviewbuddy.io_tap._io_tap_write_count", 0)
+        monkeypatch.setattr("codereviewbuddy.io_tap._CHECK_EVERY_WRITES", 3)
 
-        for i in range(5):
+        calls: list[Path] = []
+        monkeypatch.setattr("codereviewbuddy.io_tap.rotate_if_needed", lambda p, **_kw: calls.append(p))
+
+        for i in range(6):
             _log_entry(log_file, "stdin", f"line-{i}".encode(), extra={"i": i})
 
-        lines = log_file.read_text(encoding="utf-8").splitlines()
-        assert len(lines) == 3
-        assert [json.loads(line)["i"] for line in lines] == [2, 3, 4]
+        assert len(calls) == 2  # triggered at write 3 and 6
+        assert all(c == log_file for c in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -503,25 +505,22 @@ class TestInstallIoTap:
         assert sys.stdin is original_stdin
         assert sys.stdout is original_stdout
 
-    def test_install_truncates_existing_log(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_install_calls_rotate_if_needed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         monkeypatch.setenv("CODEREVIEWBUDDY_IO_TAP", "1")
         log_file = tmp_path / "io_tap.jsonl"
+        log_file.write_text("existing\n", encoding="utf-8")
         monkeypatch.setattr("codereviewbuddy.io_tap.LOG_DIR", tmp_path)
         monkeypatch.setattr("codereviewbuddy.io_tap.LOG_FILE", log_file)
-        monkeypatch.setattr("codereviewbuddy.io_tap.MAX_IO_TAP_LOG_LINES", 3)
 
-        with log_file.open("w", encoding="utf-8") as f:
-            for i in range(5):
-                f.write(json.dumps({"i": i}) + "\n")
+        calls: list[Path] = []
+        monkeypatch.setattr("codereviewbuddy.io_tap.rotate_if_needed", lambda p, **_kw: calls.append(p))
 
         original_stdin = sys.stdin
         original_stdout = sys.stdout
         try:
             result = install_io_tap()
             assert result is True
-            lines = log_file.read_text(encoding="utf-8").splitlines()
-            assert len(lines) == 3
-            assert [json.loads(line)["i"] for line in lines] == [2, 3, 4]
+            assert calls == [log_file]
         finally:
             sys.stdin = original_stdin
             sys.stdout = original_stdout

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -1,0 +1,106 @@
+"""Tests for size-based log rotation and stale PID cleanup."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from codereviewbuddy.log_rotation import (
+    DEFAULT_BACKUP_COUNT,
+    DEFAULT_MAX_BYTES,
+    cleanup_stale_pid_files,
+    rotate_if_needed,
+)
+
+
+class TestRotateIfNeeded:
+    def test_no_rotation_when_under_limit(self, tmp_path: Path):
+        log = tmp_path / "test.jsonl"
+        log.write_text("small\n", encoding="utf-8")
+        assert rotate_if_needed(log) is False
+        assert log.read_text(encoding="utf-8") == "small\n"
+
+    def test_no_rotation_when_file_missing(self, tmp_path: Path):
+        log = tmp_path / "missing.jsonl"
+        assert rotate_if_needed(log) is False
+
+    def test_rotates_when_over_limit(self, tmp_path: Path):
+        log = tmp_path / "test.jsonl"
+        log.write_text("x" * 200, encoding="utf-8")
+        assert rotate_if_needed(log, max_bytes=100) is True
+        assert not log.exists()  # original rotated away
+        assert (tmp_path / "test.jsonl.1").read_text(encoding="utf-8") == "x" * 200
+
+    def test_backup_chain(self, tmp_path: Path):
+        log = tmp_path / "test.jsonl"
+
+        # Create 3 rotations
+        for i in range(3):
+            log.write_text(f"round-{i}\n" + "x" * 200, encoding="utf-8")
+            rotate_if_needed(log, max_bytes=100, backup_count=7)
+
+        assert (tmp_path / "test.jsonl.1").read_text(encoding="utf-8").startswith("round-2")
+        assert (tmp_path / "test.jsonl.2").read_text(encoding="utf-8").startswith("round-1")
+        assert (tmp_path / "test.jsonl.3").read_text(encoding="utf-8").startswith("round-0")
+        assert not log.exists()
+
+    def test_oldest_backup_deleted(self, tmp_path: Path):
+        log = tmp_path / "test.jsonl"
+
+        # Fill up all backup slots (backup_count=2)
+        for i in range(3):
+            log.write_text(f"round-{i}\n" + "x" * 200, encoding="utf-8")
+            rotate_if_needed(log, max_bytes=100, backup_count=2)
+
+        # .1 and .2 should exist, .3 should not
+        assert (tmp_path / "test.jsonl.1").exists()
+        assert (tmp_path / "test.jsonl.2").exists()
+        assert not (tmp_path / "test.jsonl.3").exists()
+        # .1 should be the most recent
+        assert (tmp_path / "test.jsonl.1").read_text(encoding="utf-8").startswith("round-2")
+
+    def test_default_constants(self):
+        assert DEFAULT_MAX_BYTES == 2 * 1024 * 1024
+        assert DEFAULT_BACKUP_COUNT == 7
+
+    def test_oserror_returns_false(self, tmp_path: Path):
+        """Rotation on a non-writable path should fail gracefully."""
+        log = tmp_path / "nonexistent" / "deep" / "test.jsonl"
+        assert rotate_if_needed(log) is False
+
+
+class TestCleanupStalePidFiles:
+    def test_removes_stale_pid(self, tmp_path: Path):
+        pid_file = tmp_path / "server.99999.pid"
+        pid_file.write_text("999999", encoding="utf-8")  # Almost certainly not running
+        removed = cleanup_stale_pid_files(tmp_path)
+        assert removed == 1
+        assert not pid_file.exists()
+
+    def test_keeps_running_pid(self, tmp_path: Path):
+        pid_file = tmp_path / f"server.{os.getppid()}.pid"
+        pid_file.write_text(str(os.getpid()), encoding="utf-8")  # Our own PID — definitely running
+        removed = cleanup_stale_pid_files(tmp_path)
+        assert removed == 0
+        assert pid_file.exists()
+
+    def test_handles_invalid_pid_content(self, tmp_path: Path):
+        pid_file = tmp_path / "server.123.pid"
+        pid_file.write_text("not-a-number", encoding="utf-8")
+        removed = cleanup_stale_pid_files(tmp_path)
+        assert removed == 1
+        assert not pid_file.exists()
+
+    def test_empty_directory(self, tmp_path: Path):
+        removed = cleanup_stale_pid_files(tmp_path)
+        assert removed == 0
+
+    def test_ignores_non_pid_files(self, tmp_path: Path):
+        other = tmp_path / "tool_calls.jsonl"
+        other.write_text("data", encoding="utf-8")
+        removed = cleanup_stale_pid_files(tmp_path)
+        assert removed == 0
+        assert other.exists()

--- a/tests/test_write_middleware.py
+++ b/tests/test_write_middleware.py
@@ -14,6 +14,8 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pytest_mock import MockerFixture
+
 from codereviewbuddy.middleware import ISSUE_65_TRACKING_TAG, WRITE_TOOLS, WriteOperationMiddleware
 
 
@@ -62,18 +64,20 @@ class TestLogFile:
         lines = log_file.read_text(encoding="utf-8").splitlines()
         assert len(lines) == 5
 
-    def test_truncate_keeps_last_n_lines(self, middleware: WriteOperationMiddleware, tmp_log_dir: Path):
-        log_file = tmp_log_dir / "tool_calls.jsonl"
-        # Write more than MAX_LOG_LINES
-        with log_file.open("w", encoding="utf-8") as f:
-            for i in range(1100):
-                f.write(json.dumps({"i": i}) + "\n")
-        middleware._truncate_log_if_needed()
-        lines = log_file.read_text(encoding="utf-8").splitlines()
-        assert len(lines) == 1000
-        # Should keep the last entries
-        assert json.loads(lines[0])["i"] == 100
-        assert json.loads(lines[-1])["i"] == 1099
+    def test_rotation_triggers_after_n_writes(self, middleware: WriteOperationMiddleware, tmp_log_dir: Path, mocker: MockerFixture):
+        """rotate_if_needed is called once log_count reaches _CHECK_EVERY_WRITES."""
+        from codereviewbuddy.log_rotation import _CHECK_EVERY_WRITES
+
+        rotate_mock = mocker.patch("codereviewbuddy.middleware.rotate_if_needed")
+        for i in range(_CHECK_EVERY_WRITES):
+            middleware._append_log({"tool": f"t-{i}"})
+            middleware._log_count += 1
+            if middleware._log_count % _CHECK_EVERY_WRITES == 0:
+                from codereviewbuddy.middleware import rotate_if_needed as _real
+
+                _real(middleware._log_file)
+
+        rotate_mock.assert_called_once_with(middleware._log_file)
 
     def test_append_log_survives_missing_dir(self, tmp_path: Path):
         """If the log directory can't be created, middleware still works."""


### PR DESCRIPTION
Replace line-count truncation with size-based rotation (2MB × 7 backups). Shared rotate_if_needed() in log_rotation.py wired into all three log writers (gh.py, github_api.py, middleware.py, io_tap.py). Adds stale PID file cleanup on server startup.

Closes ISM-327

Closes ISM-XXX

<!-- Replace ISM-XXX with the Linear issue this PR closes (auto-transitions to Done on merge).
     Use "Ref ISM-XXX" to link without closing. Delete the line for chore PRs with no issue. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
