### PR TITLE
refactor: remove brittle action classification from triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An MCP server that helps your AI coding agent manage PR review comments from any
 
 ### Review comment management
 
-- **Triage review comments** — `triage_review_comments` filters to only actionable inline threads, suggests fix/reply actions, and includes direct GitHub URLs for each comment
+- **Triage review comments** — `triage_review_comments` filters to only actionable inline threads and includes direct GitHub URLs for each comment
 - **Get thread details** — `get_thread` fetches full conversation history for any thread by node ID
 - **Reply to anything** — inline review threads (`PRRT_`), PR-level reviews (`PRR_`), and bot issue comments (`IC_`) all routed to the correct GitHub API
 
@@ -181,7 +181,7 @@ If your MCP client reports `No module named 'fastmcp.server.tasks.routing'`, the
 | Tool | Tags | Description |
 | ---- | ---- | ----------- |
 | `summarize_review_status` | query, discovery | Lightweight stack-wide overview — start here |
-| `triage_review_comments` | query | Only actionable inline threads with suggested actions |
+| `triage_review_comments` | query | Only actionable inline threads needing attention |
 | `get_thread` | query | Full thread details by node ID — use after triage for conversation history |
 | `reply_to_comment` | command | Reply to inline threads (`PRRT_`), PR-level reviews (`PRR_`), or bot comments (`IC_`) |
 | `diagnose_ci` | query | Diagnose CI failures — finds the failed run, jobs, steps, and error lines in one call |
@@ -221,7 +221,7 @@ codereviewbuddy works **zero-config** with sensible defaults. All configuration 
 
 ```
 1. summarize_review_status()                     # Stack-wide overview — start here
-2. triage_review_comments(pr_numbers=[42, 43])   # Only actionable threads with suggested actions
+2. triage_review_comments(pr_numbers=[42, 43])   # Only actionable threads needing attention
 3. # Fix bugs flagged by triage, then:
 4. reply_to_comment(42, thread_id, "Fixed in ...")  # Reply explaining the fix
 5. diagnose_ci(pr_number=42)                     # If CI fails, diagnose in one call

--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -111,11 +111,6 @@ class TriageItem(BaseModel):
     reviewer: str = Field(description="GitHub login of the user or bot that posted this thread")
     title: str = Field(default="", description="Short title extracted from the comment (first bold text)")
     comment_url: str = Field(default="", description="Direct URL to the comment on GitHub for user navigation")
-    action: str = Field(
-        default="fix",
-        description="Suggested action: 'fix' (code change needed), 'acknowledge' (informational), "
-        "'create_issue' (track separately), 'skip' (no action), 'ambiguous' (unclear — needs user input)",
-    )
 
 
 class ActivityEvent(BaseModel):

--- a/src/codereviewbuddy/server.py
+++ b/src/codereviewbuddy/server.py
@@ -298,35 +298,6 @@ def _recovery_error(  # noqa: PLR0911
     return " ".join(parts)
 
 
-async def _elicit_ambiguous_items(result: TriageResult, ctx: Context | None) -> None:
-    """Ask the user what to do with ambiguous triage items via MCP elicitation.
-
-    Falls back gracefully when the client doesn't support elicitation —
-    items stay ``action="ambiguous"`` and the agent decides based on instructions.
-    """
-    if ctx is None:
-        return
-
-    from fastmcp.server.elicitation import AcceptedElicitation  # noqa: PLC0415
-
-    for item in result.items:
-        if item.action != "ambiguous":
-            continue
-        location = f"{item.file}:{item.line}" if item.file and item.line is not None else (item.file or "PR-level")
-        prompt = f"Ambiguous review comment at {location}"
-        if item.title:
-            prompt += f" — '{item.title}'"
-        prompt += "\nWhat should we do?"
-        try:
-            response = await ctx.elicit(prompt, ["fix", "acknowledge", "create_issue", "skip"])
-            if isinstance(response, AcceptedElicitation):
-                item.action = str(response.data)
-            else:
-                item.action = "skip"
-        except Exception:
-            logger.debug("Elicitation not supported by client, keeping action=ambiguous", exc_info=True)
-
-
 mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=True, transform_errors=True))
 mcp.add_middleware(TimingMiddleware())
 mcp.add_middleware(LoggingMiddleware(include_payloads=True, max_payload_length=500))
@@ -574,9 +545,7 @@ async def triage_review_comments(
         ctx = get_context()
         cwd = await _get_workspace_cwd(ctx)
         _check_auto_detect_prerequisites(cwd, has_pr=True, has_repo=repo is not None)
-        result = await comments.triage_review_comments(pr_numbers, repo=repo, owner_logins=owner_logins, cwd=cwd, ctx=ctx)
-        await _elicit_ambiguous_items(result, ctx)
-        return result  # noqa: TRY300 — intentionally inside try to catch elicitation errors
+        return await comments.triage_review_comments(pr_numbers, repo=repo, owner_logins=owner_logins, cwd=cwd, ctx=ctx)
     except Exception as exc:
         logger.exception("triage_review_comments failed")
         return TriageResult(error=_recovery_error(exc, tool_name="triage_review_comments", repo=repo))

--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -423,28 +423,6 @@ def _extract_title(body: str) -> str:
     return match.group(1).strip() if match else ""
 
 
-_FIX_PATTERN = re.compile(r"(\U0001f534|\U0001f6a9|\bbug\b|\bcritical\b|\bbreaking\b|\bmust fix\b|\bsecurity\b)", re.IGNORECASE)
-_ACKNOWLEDGE_PATTERN = re.compile(
-    r"(\U0001f4dd|\U0001f7e1|\binfo\b|\bnote\b|\bnit\b|\bstyle\b|\bnitpick\b|\bminor\b|\bconsider\b)", re.IGNORECASE
-)
-
-
-def _classify_action(thread: ReviewThread) -> str:
-    """Classify the suggested action for a triage item based on comment content.
-
-    Returns:
-        "fix" — clear code change needed (bug/critical markers).
-        "acknowledge" — informational, just reply (info/nit/style markers).
-        "ambiguous" — unclear intent, needs user input.
-    """
-    body = thread.comments[0].body if thread.comments else ""
-    if _FIX_PATTERN.search(body):
-        return "fix"
-    if _ACKNOWLEDGE_PATTERN.search(body):
-        return "acknowledge"
-    return "ambiguous"
-
-
 def _has_owner_reply(thread: ReviewThread, owner_logins: frozenset[str]) -> bool:
     """Check if any comment in the thread is from the repo owner / agent."""
     return any(c.author in owner_logins for c in thread.comments)
@@ -462,7 +440,6 @@ def _thread_to_triage_item(thread: ReviewThread) -> TriageItem:
         reviewer=thread.reviewer,
         title=_extract_title(body),
         comment_url=first.url if first else "",
-        action=_classify_action(thread),
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -405,69 +404,6 @@ class TestErrorHandlers:
         mocker.patch("codereviewbuddy.server.comments.reply_to_comment", side_effect=RuntimeError("boom"))
         result = await reply_to_comment(thread_id="PRRT_abc", body="test", pr_number=1)
         assert "reply_to_comment failed" in result
-
-
-@pytest.mark.usefixtures("patch_server_context")
-class TestElicitAmbiguousItems:
-    """Tests for _elicit_ambiguous_items — elicitation flow with fallback."""
-
-    async def test_elicit_updates_ambiguous_action(self, mocker: MockerFixture):
-        from fastmcp.server.elicitation import AcceptedElicitation
-
-        from codereviewbuddy.models import TriageItem, TriageResult
-        from codereviewbuddy.server import _elicit_ambiguous_items
-
-        ctx = mocker.MagicMock()
-        accepted = AcceptedElicitation(data="fix")
-        ctx.elicit = AsyncMock(return_value=accepted)
-
-        result = TriageResult(
-            items=[TriageItem(thread_id="PRRT_1", pr_number=42, reviewer="bot", action="ambiguous", file="a.py", line=1)],
-            total=1,
-        )
-        await _elicit_ambiguous_items(result, ctx)
-        assert result.items[0].action == "fix"
-
-    async def test_elicit_skips_non_ambiguous(self, mocker: MockerFixture):
-        from codereviewbuddy.models import TriageItem, TriageResult
-        from codereviewbuddy.server import _elicit_ambiguous_items
-
-        ctx = mocker.MagicMock()
-        ctx.elicit = AsyncMock()
-
-        result = TriageResult(
-            items=[TriageItem(thread_id="PRRT_1", pr_number=42, reviewer="bot", action="fix")],
-            total=1,
-        )
-        await _elicit_ambiguous_items(result, ctx)
-        ctx.elicit.assert_not_called()
-        assert result.items[0].action == "fix"
-
-    async def test_elicit_fallback_on_unsupported_client(self, mocker: MockerFixture):
-        from codereviewbuddy.models import TriageItem, TriageResult
-        from codereviewbuddy.server import _elicit_ambiguous_items
-
-        ctx = mocker.MagicMock()
-        ctx.elicit = AsyncMock(side_effect=RuntimeError("Elicitation not supported"))
-
-        result = TriageResult(
-            items=[TriageItem(thread_id="PRRT_1", pr_number=42, reviewer="bot", action="ambiguous")],
-            total=1,
-        )
-        await _elicit_ambiguous_items(result, ctx)
-        # Should stay "ambiguous" — graceful fallback
-        assert result.items[0].action == "ambiguous"
-
-    async def test_elicit_noop_without_ctx(self):
-        from codereviewbuddy.models import TriageItem, TriageResult
-        from codereviewbuddy.server import _elicit_ambiguous_items
-
-        result = TriageResult(
-            items=[TriageItem(thread_id="PRRT_1", pr_number=42, reviewer="bot", action="ambiguous")],
-            total=1,
-        )
-        await _elicit_ambiguous_items(result, None)
-        assert result.items[0].action == "ambiguous"
 
 
 class TestResolveThreadPrNumber:

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 
 from codereviewbuddy.models import CommentStatus, ReviewComment, ReviewThread
 from codereviewbuddy.tools.comments import (
-    _classify_action,
     _extract_title,
     _has_owner_reply,
     triage_review_comments,
@@ -71,40 +70,6 @@ class TestExtractTitle:
 
     def test_no_bold(self):
         assert not _extract_title("No bold text here")
-
-
-class TestClassifyAction:
-    def test_bug_marker_returns_fix(self):
-        assert _classify_action(_thread(body="🔴 **Bug: Missing null check**")) == "fix"
-
-    def test_critical_keyword_returns_fix(self):
-        assert _classify_action(_thread(body="**Critical: This will crash in production**")) == "fix"
-
-    def test_flagged_marker_returns_fix(self):
-        assert _classify_action(_thread(body="🚩 **Flagged: Security issue**")) == "fix"
-
-    def test_info_marker_returns_acknowledge(self):
-        assert _classify_action(_thread(body="📝 **Info: Consider using a constant**")) == "acknowledge"
-
-    def test_nit_keyword_returns_acknowledge(self):
-        assert _classify_action(_thread(body="**Nit: trailing whitespace**")) == "acknowledge"
-
-    def test_style_keyword_returns_acknowledge(self):
-        assert _classify_action(_thread(body="Style suggestion: use snake_case here")) == "acknowledge"
-
-    def test_consider_keyword_returns_acknowledge(self):
-        assert _classify_action(_thread(body="Consider extracting this into a helper")) == "acknowledge"
-
-    def test_vague_comment_returns_ambiguous(self):
-        assert _classify_action(_thread(body="This could be improved")) == "ambiguous"
-
-    def test_empty_body_returns_ambiguous(self):
-        assert _classify_action(_thread(body="")) == "ambiguous"
-
-    def test_no_comments_returns_ambiguous(self):
-        thread = _thread()
-        thread.comments = []
-        assert _classify_action(thread) == "ambiguous"
 
 
 class TestHasOwnerReply:
@@ -338,5 +303,3 @@ class TestTriageNarrowIntegration:
         assert inline.title == "null check missing"
         assert inline.file == "src/main.py"
         assert inline.line == 10
-        # "Bug" keyword → action should be "fix"
-        assert inline.action == "fix"


### PR DESCRIPTION
Remove the regex-based action field (fix/acknowledge/ambiguous) from
TriageItem and the associated elicitation flow. The classification was
fragile—dependent on AI reviewer comment formatting—and the consuming
LLM agent can make this judgment itself after reading the full thread
via get_thread.

<!-- Closes #, Related to # -->

<!-- Replace ISM-XXX with the Linear issue this PR closes (auto-transitions to Done on merge).
     Use "Ref ISM-XXX" to link without closing. Delete the line for chore PRs with no issue. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/codereviewbuddy/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
