### PR TITLE
feat: surface isOutdated flag on triaged review threads

### DIFF
--- a/src/codereviewbuddy/models.py
+++ b/src/codereviewbuddy/models.py
@@ -35,6 +35,7 @@ class ReviewThread(BaseModel):
     reviewer: str = Field(description="GitHub login of the user or bot that posted the first comment")
     comments: list[ReviewComment] = Field(default_factory=list, description="Comments in this thread")
     is_pr_review: bool = Field(default=False, description="True for PR-level reviews (PRR_ IDs) — not resolvable via resolveReviewThread")
+    is_outdated: bool = Field(default=False, description="True when the diff has changed since the comment was posted")
 
 
 class StackPR(BaseModel):
@@ -111,6 +112,7 @@ class TriageItem(BaseModel):
     reviewer: str = Field(description="GitHub login of the user or bot that posted this thread")
     title: str = Field(default="", description="Short title extracted from the comment (first bold text)")
     comment_url: str = Field(default="", description="Direct URL to the comment on GitHub for user navigation")
+    is_outdated: bool = Field(default=False, description="True when the diff changed since comment was posted — consider deprioritizing")
 
 
 class ActivityEvent(BaseModel):

--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -37,6 +37,7 @@ query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
         nodes {
           id
           isResolved
+          isOutdated
           comments(first: 10) {
             nodes {
               author { login }
@@ -132,6 +133,7 @@ def _parse_threads(raw_threads: list[dict[str, Any]], pr_number: int) -> list[Re
                 line=first_comment.get("line"),
                 reviewer=author,
                 comments=comments,
+                is_outdated=node.get("isOutdated", False),
             )
         )
     return threads
@@ -440,6 +442,7 @@ def _thread_to_triage_item(thread: ReviewThread) -> TriageItem:
         reviewer=thread.reviewer,
         title=_extract_title(body),
         comment_url=first.url if first else "",
+        is_outdated=thread.is_outdated,
     )
 
 

--- a/src/codereviewbuddy/tools/comments.py
+++ b/src/codereviewbuddy/tools/comments.py
@@ -204,6 +204,7 @@ query($id: ID!) {
       __typename
       id
       isResolved
+      isOutdated
       pullRequest { number }
       comments(first: 50) {
         nodes {

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -202,6 +202,7 @@ class TestNodeToReviewThread:
         assert thread.reviewer == "ai-reviewer-a[bot]"
         assert thread.file == "src/codereviewbuddy/gh.py"
         assert thread.status == "unresolved"
+        assert thread.is_outdated is True
         assert len(thread.comments) == 1
 
     def test_pr_review(self):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -27,6 +27,7 @@ from codereviewbuddy.tools.comments import (
 SAMPLE_THREAD_NODE = {
     "id": "PRRT_kwDOtest123",
     "isResolved": False,
+    "isOutdated": True,
     "comments": {
         "nodes": [
             {
@@ -134,6 +135,30 @@ class TestParseThreads:
         node = {"id": "PRRT_empty", "isResolved": False, "comments": {"nodes": []}}
         threads = _parse_threads([node], pr_number=42)
         assert len(threads) == 0
+
+    def test_surfaces_is_outdated(self):
+        threads = _parse_threads([SAMPLE_THREAD_NODE], pr_number=42)
+        assert threads[0].is_outdated is True
+
+    def test_defaults_is_outdated_false(self):
+        """Missing isOutdated in GraphQL response defaults to False."""
+        node = {
+            "id": "PRRT_no_outdated",
+            "isResolved": False,
+            "comments": {
+                "nodes": [
+                    {
+                        "author": {"login": "bot"},
+                        "body": "test",
+                        "createdAt": "2026-02-06T10:00:00Z",
+                        "path": "f.py",
+                        "line": 1,
+                    }
+                ]
+            },
+        }
+        threads = _parse_threads([node], pr_number=42)
+        assert threads[0].is_outdated is False
 
     def test_resolved_status(self):
         threads = _parse_threads([SAMPLE_RESOLVED_THREAD], pr_number=42)

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -30,6 +30,7 @@ def _thread(
     file: str = "src/main.py",
     line: int = 10,
     is_pr_review: bool = False,
+    is_outdated: bool = False,
     extra_comments: list[ReviewComment] | None = None,
 ) -> ReviewThread:
     comments = [
@@ -50,6 +51,7 @@ def _thread(
         reviewer=reviewer,
         comments=comments,
         is_pr_review=is_pr_review,
+        is_outdated=is_outdated,
     )
 
 
@@ -215,6 +217,18 @@ class TestTriageReviewComments:
         result = await triage_review_comments([42])
         assert result.total == 1
 
+    async def test_outdated_thread_included_but_flagged(self, mocker: MockerFixture):
+        """Outdated threads should appear in triage with is_outdated=True."""
+        outdated = _thread(thread_id="PRRT_old", is_outdated=True, body="**Bug: stale issue**")
+        fresh = _thread(thread_id="PRRT_new", is_outdated=False, body="**Bug: fresh issue**")
+        self._mock_list(mocker, [outdated, fresh])
+
+        result = await triage_review_comments([42], repo="o/r")
+        assert result.total == 2
+        by_id = {item.thread_id: item for item in result.items}
+        assert by_id["PRRT_old"].is_outdated is True
+        assert by_id["PRRT_new"].is_outdated is False
+
     async def test_empty_result_message(self, mocker: MockerFixture):
         """Empty triage should return a helpful message."""
         self._mock_list(mocker, [])
@@ -240,6 +254,7 @@ GRAPHQL_RESPONSE_WITH_THREADS = {
                         {
                             "id": "PRRT_inline1",
                             "isResolved": False,
+                            "isOutdated": True,
                             "comments": {
                                 "nodes": [
                                     {
@@ -298,8 +313,9 @@ class TestTriageNarrowIntegration:
         assert "PRRT_inline1" in ids  # unresolved inline
         assert "PRRT_resolved" not in ids  # resolved — filtered out
 
-        # Verify title was extracted from bold text
+        # Verify title and is_outdated were extracted
         inline = result.items[0]
         assert inline.title == "null check missing"
         assert inline.file == "src/main.py"
         assert inline.line == 10
+        assert inline.is_outdated is True


### PR DESCRIPTION
## Summary

Surface GitHub's `isOutdated` flag on `ReviewThread` and `TriageItem` so consuming agents can deprioritize threads that refer to stale code (the diff changed since the comment was posted).

- Added `is_outdated` field to `ReviewThread` and `TriageItem` models
- Added `isOutdated` to the GraphQL threads query
- Parsed and passed through from GraphQL response to triage output
- Informational only — outdated threads still appear in triage, not filtered

Closes ISM-387